### PR TITLE
fix #20: Render SVG icons and text in Signin

### DIFF
--- a/packages/ui/src/pages/Signup.tsx
+++ b/packages/ui/src/pages/Signup.tsx
@@ -4,6 +4,7 @@ import { GoogleAuthProvider } from "firebase/auth";
 import GoogleIcon from "../assets/google.svg";
 import GithubIcon from "../assets/github.svg";
 import { useRouter } from "next/navigation";
+import { Button } from "../shad/ui/button"
 
 const provider = new GoogleAuthProvider();
 
@@ -56,20 +57,18 @@ export const Signin = () => {
                                     <p className='font-light text-sm text-gray-600'>
                                         Log in to continue to DailyCode.
                                     </p>
-                                    <button
-                                        type='submit'
-                                        className='w-full flex justify-center items-center gap-2 py-3 px-4 border rounded font-light text-md hover:bg-gray-200 focus:outline-none focus:ring-2 '
-                                        onClick={() => onSignin()}
+                                    <Button
+                                        className='w-full flex justify-center items-center gap-2 py-3 px-4 border rounded font-light text-md hover:bg-gray-200 focus:outline-none focus:ring-2 -mt-2 h-auto'
                                     >
-                                        <img src={GoogleIcon} className='w-5 h-5 mr-2' />
+                                        <img src={GoogleIcon.src} className='w-5 h-5 mr-2' />
                                         Continue with Google
-                                    </button>
-                                    <button
-                                        className='w-full flex justify-center items-center gap-2 py-3 px-4 border rounded font-light text-md hover:bg-gray-200 focus:outline-none focus:ring-2 -mt-2'
+                                    </Button>
+                                    <Button
+                                        className='w-full flex justify-center items-center gap-2 py-3 px-4 border rounded font-light text-md hover:bg-gray-200 focus:outline-none focus:ring-2 -mt-2 h-auto'
                                     >
-                                        <img src={GithubIcon} className='w-5 h-5 mr-2' />
+                                        <img src={GithubIcon.src} className='w-5 h-5 mr-2' />
                                         Continue with Github
-                                    </button>
+                                    </Button>
                                 </div>
                             </div>
                         </div>
@@ -79,3 +78,4 @@ export const Signin = () => {
         </div>
     )
 }
+export {GithubIcon};


### PR DESCRIPTION
# Pull Request Description
This pull request resolves issue #20 .

## Changes Made

### SVG Rendering
- Previously, importing SVG resulted in an [object object] when used inside the image source. 
- Modified the code to use `GithubIcon.src` instead, resolving the issue.
- - Modified the code to use `GoogleIcon.src` instead, resolving the issue.

### Button Component
- Utilized the `shadcn` button component to render the button text.