### PR TITLE
Removed the Header and Title in Notion Rendered

### DIFF
--- a/packages/ui/src/NotionRenderer.tsx
+++ b/packages/ui/src/NotionRenderer.tsx
@@ -15,6 +15,13 @@ import "katex/dist/katex.min.css";
 export const NotionRenderer = ({ recordMap }: { recordMap: any }) => {
   return (
     <div className="">
+      <style>
+        {`
+          .notion-header {
+            display: none !important;
+          }
+        `}
+      </style>
       <div className="rounded-full">
         <NotionRendererLib
           components={{


### PR DESCRIPTION
Removed the Header and Title Displayed on the Notion Page Renderer.

Fixes #34 

![Screenshot from 2024-02-02 11-02-39](https://github.com/code100x/daily-code/assets/132639448/a5c8d566-1035-4fba-9a15-bc562bd88b0c)
