### PR TITLE
Fix #44: Add system theme to notion

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }): JSX.Element {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={cn("min-h-screen bg-background font-sans antialiased", fontSans.variable)}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <Providers>

--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -32,11 +32,11 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
-                stroke-width="1.5"
+                strokeWidth="1.5"
                 stroke="currentColor"
                 className="w-4 h-4"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
               </svg>
             </div>
           </Button>
@@ -52,11 +52,11 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"
-                stroke-width="1.5"
+                strokeWidth="1.5"
                 stroke="currentColor"
                 className="w-4 h-4"
               >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
               </svg>
             </div>
             Prev

--- a/packages/ui/src/NotionRenderer.tsx
+++ b/packages/ui/src/NotionRenderer.tsx
@@ -14,7 +14,8 @@ import { useTheme } from "next-themes";
 
 // Week-4-1-647987d9b1894c54ba5c822978377910
 export const NotionRenderer = ({ recordMap }: { recordMap: any }) => {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
+
   return (
     <div className="">
       <style>
@@ -31,7 +32,7 @@ export const NotionRenderer = ({ recordMap }: { recordMap: any }) => {
           }}
           recordMap={recordMap}
           fullPage={true}
-          darkMode={theme == "dark"}
+          darkMode={resolvedTheme === "dark"}
         />
       </div>
     </div>


### PR DESCRIPTION
# Pull Request Description
This pull request resolves issue #44 .

## Changes Made

### Resolved Theme Integration
- Previously, the NotionRenderer utilized the `theme` property from the **useTheme** hook, which did not account for the system theme. I have modified it to use `resolvedTheme` property to dynamically provide dark and light themes based on the system theme.

### Svg Property Casing Standardization
- Adjusted property casing in SVG elements from kebab-case to camelCase (e.g., stroke-width to strokeWidth), aligning with best practices.

### Hydration Error Mitigation
- Addressed a hydration error in the next-themes client component, which was causing issues by setting properties on HTML attributes. To mitigate this, I have implemented the use of suppressHydrationWarning to prevent this error. This issue was particularly noticeable in conjunction with the app router.