### PR TITLE
Improvement to the prev and next buttons for BlogAppbar

### DIFF
--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -34,11 +34,10 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
         <div className="flex space-x-2">
           <Link
             prefetch={true}
-            href={
-              problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]}` : `/tracks/${track.id}`
-            }
+            href={problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]}` : ``}
+            style={{ cursor: problemIndex !== 0 ? "pointer" : "not-allowed" }}
           >
-            <Button variant="outline" className="ml-2 bg-black text-white">
+            <Button variant="outline" className="ml-2 bg-black text-white" disabled={problemIndex !== 0 ? false : true}>
               <div className="pr-2">
                 <ChevronLeftIcon />
               </div>
@@ -50,11 +49,16 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
             prefetch={true}
             href={
               problemIndex + 1 === track.problems.length
-                ? `/tracks/${track.id}`
+                ? ``
                 : `/tracks/${track.id}/${track.problems[problemIndex + 1]}`
             }
+            style={{ cursor: problemIndex + 1 !== track.problems.length ? "pointer" : "not-allowed" }}
           >
-            <Button variant="outline" className="bg-black text-white">
+            <Button
+              variant="outline"
+              className="bg-black text-white"
+              disabled={problemIndex + 1 !== track.problems.length ? false : true}
+            >
               Next
               <div className="pl-2">
                 <ChevronRightIcon />


### PR DESCRIPTION
This Pull request is raised in reference to improvement requested #60  

In the first and last pages of a track the prev and next button are greyed out respectively. Along with that the mouse pointer type is changed to **not-allowed** instead of a clickable option.