### PR TITLE
fixed theme issue on reload

### DIFF
--- a/packages/ui/src/NotionRenderer.tsx
+++ b/packages/ui/src/NotionRenderer.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { NotionRenderer as NotionRendererLib } from "react-notion-x";
 import { Code } from "react-notion-x/build/third-party/code";
+import { useEffect, useState } from "react";
 
 // core styles shared by all of react-notion-x (required)
 import "react-notion-x/src/styles.css";
@@ -15,6 +16,15 @@ import { useTheme } from "next-themes";
 // Week-4-1-647987d9b1894c54ba5c822978377910
 export const NotionRenderer = ({ recordMap }: { recordMap: any }) => {
   const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
 
   return (
     <div className="">


### PR DESCRIPTION
This pr is raised in reference to the issue #63 . 

The discrepancy between the selected theme and the track page theme was due to **hydration** issue. There is a possiblity of the theme holding diffrent values on server and client side

I have used a simple mount variable to check for page mounting and then used the resolvedTheme for the condition. This takes care of the theme holding its value even after page reloads