### PR TITLE
feat: Page navigation using keyboard, active current page on dropdown

### DIFF
--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -1,21 +1,55 @@
 import { Button } from "./shad/ui/button";
 import { Problem, Track } from "@repo/store";
-import { ReactNode, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from "react";
 import Link from "next/link";
 import { ChevronLeftIcon, ChevronRightIcon, MoonIcon, SunIcon } from "@radix-ui/react-icons";
 import { ModeToggle } from "./ModeToggle";
 import { PageToggle } from "./PageToggle";
 
 export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track }) => {
+  const router = useRouter();
+
+  const backButtonRef = useRef<HTMLButtonElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+
   const problemIndex = useMemo(() => {
     return track.problems.findIndex((p) => p === problem.id);
   }, [track, problem]);
+
+  const nextLink =
+    problemIndex + 1 === track.problems.length
+      ? `/tracks/${track.id}`
+      : `/tracks/${track.id}/${track.problems[problemIndex + 1]}`;
+
+  const prevLink =
+    problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]}` : `/tracks/${track.id}`;
 
   let totalPages = Array.from({ length: track.problems.length }, (_, i) => i + 1);
 
   function setTheme(arg0: string) {
     throw new Error("Function not implemented.");
   }
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft") {
+        router.push(prevLink);
+        backButtonRef.current?.focus();
+      } else if (event.key === "ArrowRight") {
+        router.push(nextLink);
+        nextButtonRef.current?.focus();
+      }
+    },
+    [prevLink, nextLink, router]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   return (
     <div className="flex flex-col items-center justify-between p-4 border-b shadow-md w-full dark:bg-zinc-950 bg-zinc-50 sticky top-0 z-50">
@@ -32,13 +66,8 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
         </div>
 
         <div className="flex space-x-2">
-          <Link
-            prefetch={true}
-            href={
-              problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]}` : `/tracks/${track.id}`
-            }
-          >
-            <Button variant="outline" className="ml-2 bg-black text-white">
+          <Link prefetch={true} href={prevLink}>
+            <Button variant="outline" className="ml-2 bg-black text-white" ref={backButtonRef}>
               <div className="pr-2">
                 <ChevronLeftIcon />
               </div>
@@ -46,15 +75,8 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
             </Button>
           </Link>
 
-          <Link
-            prefetch={true}
-            href={
-              problemIndex + 1 === track.problems.length
-                ? `/tracks/${track.id}`
-                : `/tracks/${track.id}/${track.problems[problemIndex + 1]}`
-            }
-          >
-            <Button variant="outline" className="bg-black text-white">
+          <Link prefetch={true} href={nextLink}>
+            <Button variant="outline" className="bg-black text-white" ref={nextButtonRef}>
               Next
               <div className="pl-2">
                 <ChevronRightIcon />

--- a/packages/ui/src/PageToggle.tsx
+++ b/packages/ui/src/PageToggle.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./shad/ui/dropdown-menu";
 import { Button } from "./shad/ui/button";
 import { Problem } from "@repo/store";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { getFunction } from "@repo/common";
 import { ArrowTopRightIcon } from "@radix-ui/react-icons";
 
@@ -17,7 +17,10 @@ async function getProblem(problemId: string | null): Promise<Problem | null> {
 
 export function PageToggle(props: any) {
   const router = useRouter();
+  const params = useParams<{ trackIds: string[] }>();
+
   const [allProblemTitles, setAllProblemTitles] = useState<{ id: string; title: string }[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     const fetchProblemTitles = async () => {
@@ -33,8 +36,21 @@ export function PageToggle(props: any) {
     fetchProblemTitles();
   }, [props.allProblemIds]); // Run the effect whenever allProblemIds changes
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "/") {
+        setIsOpen((prevState) => !prevState);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
   return (
-    <DropdownMenu>
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
         <Button variant="outline">
           Jump To
@@ -45,7 +61,11 @@ export function PageToggle(props: any) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {allProblemTitles.map((problem: { id: string; title: string }, index: number) => (
-          <DropdownMenuItem key={index} onClick={() => router.push(`/tracks/${props.track.id}/${problem.id}`)}>
+          <DropdownMenuItem
+            key={index}
+            onClick={() => router.push(`/tracks/${props.track.id}/${problem.id}`)}
+            className={`cursor-pointer ${params?.trackIds?.includes(problem.id) ? "bg-muted-foreground" : ""}`}
+          >
             {index + 1} - {problem.title}
           </DropdownMenuItem>
         ))}


### PR DESCRIPTION
- User can Go to the `Next` or `Prev` Page using the Keyboard's `Left` or `Right` Button
- Using the `/` Key user can toggle the `Jump To` Button
- Showing Current active Menu Item based on the current page 

Demo - https://jmp.sh/JkSgDriW