### PR TITLE
Fix: #100 Unnecessary Firebase function calls and redirecting

### DIFF
--- a/apps/web/app/tracks/[...trackIds]/page.tsx
+++ b/apps/web/app/tracks/[...trackIds]/page.tsx
@@ -1,16 +1,12 @@
 import { getFunction } from "@repo/common";
 import { Problem, Track } from "@repo/store";
-import { RedirectToLastSolved } from "../../../components/RedirectToLastSolved";
 import { NotionAPI } from "notion-client";
 import { LessonView } from "@repo/ui/components";
 import { redirect } from "next/navigation";
 
 const notion = new NotionAPI();
 
-async function getProblem(problemId: string | null): Promise<Problem | null> {
-  if (!problemId) {
-    return null;
-  }
+async function getProblem(problemId: string): Promise<Problem> {
   const getProblem = getFunction("getProblem");
   const response: any = await getProblem({ problemId });
   return response.data.problem;
@@ -29,23 +25,24 @@ async function getTrack(trackId: string): Promise<{
 }
 
 export default async function TrackComponent({ params }: { params: { trackIds: string[] } }) {
-  // @ts-ignore
-  const trackId: string = params.trackIds[0];
-  const problemId = params.trackIds[1];
+  const trackId: string = params.trackIds[0]!;
+  const problemId: string = params.trackIds[1]!;
   let notionRecordMap = null;
   if (trackId === "43XrfL4n0LgSnTkSB4rO") {
     redirect("/tracks/oAjvkeRNZThPMxZf4aX5");
   }
 
-  //@ts-ignore
-  const [problemDetails, trackDetails]: [Problem, { track: Track }] = await Promise.all([
-    getProblem(problemId || null),
+  const [problemDetails, { track }]: [Problem, { track: Track }] = await Promise.all([
+    getProblem(problemId),
     getTrack(trackId),
   ]);
 
-  if (!problemId) {
-    return <RedirectToLastSolved trackId={trackId} />;
-  }
+  const allProblemTitles = await Promise.all(
+    track.problems.map(async (problemId) => {
+      const problem = await getProblem(problemId);
+      return { id: problemId, title: problem?.title || "" };
+    })
+  );
 
   if (problemDetails?.notionDocId) {
     notionRecordMap = await notion.getPage(problemDetails.notionDocId);
@@ -55,7 +52,8 @@ export default async function TrackComponent({ params }: { params: { trackIds: s
     <div>
       <LessonView
         showAppBar
-        track={trackDetails.track}
+        allProblems={allProblemTitles}
+        track={track}
         problem={{
           ...problemDetails,
           notionRecordMap,

--- a/apps/web/screens/Landing.tsx
+++ b/apps/web/screens/Landing.tsx
@@ -30,7 +30,7 @@ export async function Landing() {
         <ul className="p-8 md:20 grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-2">
           {tracks.map((t: Track) => (
             <li key={t.id}>
-              <Link className="max-w-screen-md w-full" href={`/tracks/${t.id}`}>
+              <Link className="max-w-screen-md w-full" href={`/tracks/${t.id}/${t.problems[0]}`}>
                 <TrackCard track={t} />
               </Link>
             </li>

--- a/packages/store/src/atoms/tracks.ts
+++ b/packages/store/src/atoms/tracks.ts
@@ -21,3 +21,8 @@ export interface Track {
   problems: string[];
   description: string;
 }
+
+export interface AllProblems {
+  id: string;
+  title: string;
+}

--- a/packages/ui/src/Blog.tsx
+++ b/packages/ui/src/Blog.tsx
@@ -1,14 +1,25 @@
 "use client";
-import { Problem, Track } from "@repo/store";
+import { AllProblems, Problem, Track } from "@repo/store";
 import { BlogAppbar } from "./BlogAppbar";
 import { NotionRenderer } from "./NotionRenderer";
 import useMountStatus from "./hooks/useMountStatus";
 
-export const Blog = ({ problem, track, showAppBar, isPdfRequested }: { problem: Problem; track: Track; showAppBar: Boolean, isPdfRequested: Boolean }) => {
+export const Blog = ({
+  problem,
+  track,
+  allProblems,
+  showAppBar,
+  isPdfRequested,
+}: {
+  problem: Problem;
+  track: Track;
+  allProblems: AllProblems[];
+  showAppBar: Boolean;
+  isPdfRequested: Boolean;
+}) => {
   const mounted = useMountStatus();
 
-  if(isPdfRequested == undefined || !isPdfRequested)
-  {
+  if (isPdfRequested == undefined || !isPdfRequested) {
     if (!mounted) {
       return null;
     }
@@ -16,7 +27,7 @@ export const Blog = ({ problem, track, showAppBar, isPdfRequested }: { problem: 
 
   return (
     <div>
-      {showAppBar && <BlogAppbar problem={problem} track={track} />}
+      {showAppBar && <BlogAppbar problem={problem} track={track} allProblems={allProblems} />}
       <NotionRenderer recordMap={problem.notionRecordMap} />
     </div>
   );

--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -1,12 +1,20 @@
 import { Button } from "./shad/ui/button";
-import { Problem, Track } from "@repo/store";
+import { AllProblems, Problem, Track } from "@repo/store";
 import { ReactNode, useMemo } from "react";
 import Link from "next/link";
 import { ChevronLeftIcon, ChevronRightIcon, DownloadIcon } from "@radix-ui/react-icons";
 import { ModeToggle } from "./ModeToggle";
 import { PageToggle } from "./PageToggle";
 
-export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track }) => {
+export const BlogAppbar = ({
+  problem,
+  allProblems,
+  track,
+}: {
+  problem: Problem;
+  allProblems: AllProblems[];
+  track: Track;
+}) => {
   const problemIndex = useMemo(() => {
     return track.problems.findIndex((p) => p === problem.id);
   }, [track, problem]);
@@ -19,8 +27,8 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
 
   return (
     <div className="flex flex-col items-center justify-between p-4 border-b shadow-md w-full dark:bg-zinc-950 bg-zinc-50 sticky top-0 z-50 pt-1">
-    <div className="w-full flex flex-col items-center md:flex-row md:items-center md:justify-between mr-2">
-      <div className="dark:text-zinc-100 text-zinc-950 font-semibold text-3xl mb-2 md:mb-0">
+      <div className="w-full flex flex-col items-center md:flex-row md:items-center md:justify-between mr-2">
+        <div className="dark:text-zinc-100 text-zinc-950 font-semibold text-3xl mb-2 md:mb-0">
           <Link href={"/"}>DailyCode</Link>
         </div>
 
@@ -28,7 +36,7 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
           {problem.title} ({problemIndex + 1} / {track.problems.length})
         </p>
         <div>
-          <PageToggle allProblemIds={track.problems} track={track} />
+          <PageToggle allProblems={allProblems} track={track} />
         </div>
 
         <div className="flex space-x-2">

--- a/packages/ui/src/LessonView.tsx
+++ b/packages/ui/src/LessonView.tsx
@@ -1,15 +1,17 @@
 import { Blog } from "./Blog";
 import { CodeProblemRenderer } from "./CodeProblemRenderer";
-import { Track, Problem } from "@repo/store";
+import { Track, Problem, AllProblems } from "@repo/store";
 
 export const LessonView = ({
   problem,
   track,
+  allProblems,
   showAppBar,
-  isPdfRequested
+  isPdfRequested,
 }: {
   problem: Problem;
   track: Track;
+  allProblems: AllProblems[];
   showAppBar?: Boolean;
   isPdfRequested?: Boolean;
 }) => {
@@ -18,7 +20,15 @@ export const LessonView = ({
   }
 
   if (problem.type === "blog") {
-    return <Blog problem={problem} track={track} showAppBar={!!showAppBar} isPdfRequested={isPdfRequested} />;
+    return (
+      <Blog
+        problem={problem}
+        track={track}
+        allProblems={allProblems}
+        showAppBar={!!showAppBar}
+        isPdfRequested={isPdfRequested}
+      />
+    );
   }
   return <div>Not found</div>;
 };

--- a/packages/ui/src/PageToggle.tsx
+++ b/packages/ui/src/PageToggle.tsx
@@ -1,38 +1,12 @@
 import { ArrowTopRightIcon } from "@radix-ui/react-icons";
-import { getFunction } from "@repo/common";
-import { Problem } from "@repo/store";
+import { AllProblems, Track } from "@repo/store";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 import { cn } from "../lib/utils";
 import { Button } from "./shad/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./shad/ui/dropdown-menu";
 
-async function getProblem(problemId: string | null): Promise<Problem | null> {
-  if (!problemId) {
-    return null;
-  }
-  const getProblem = getFunction("getProblem");
-  const response: any = await getProblem({ problemId });
-  return response.data.problem;
-}
-
-export function PageToggle(props: any) {
+export function PageToggle({ allProblems, track }: { allProblems: AllProblems[]; track: Track }) {
   const router = useRouter();
-  const [allProblemTitles, setAllProblemTitles] = useState<{ id: string; title: string }[]>([]);
-
-  useEffect(() => {
-    const fetchProblemTitles = async () => {
-      const titles = await Promise.all(
-        props.allProblemIds.map(async (problemId: string) => {
-          const problemDetails = await getProblem(problemId);
-          return { id: problemId, title: problemDetails?.title || "" };
-        })
-      );
-      setAllProblemTitles(titles);
-    };
-
-    fetchProblemTitles();
-  }, [props.allProblemIds]); // Run the effect whenever allProblemIds changes
 
   return (
     <DropdownMenu>
@@ -45,8 +19,8 @@ export function PageToggle(props: any) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className={cn("overflow-y-auto max-h-[80vh]")}>
-        {allProblemTitles.map((problem: { id: string; title: string }, index: number) => (
-          <DropdownMenuItem key={index} onClick={() => router.push(`/tracks/${props.track.id}/${problem.id}`)}>
+        {allProblems.map((problem: { id: string; title: string }, index: number) => (
+          <DropdownMenuItem key={index} onClick={() => router.push(`/tracks/${track.id}/${problem.id}`)}>
             {index + 1} - {problem.title}
           </DropdownMenuItem>
         ))}


### PR DESCRIPTION
#100 
# Pull Request Description
This pull request removes function call to firebase from frontend and move it to backend to utilize nextjs caching

### Before:
https://github.com/code100x/daily-code/assets/66407522/59b7e316-360c-4021-9825-ccc36ce42e9a
### After: 
https://github.com/code100x/daily-code/assets/66407522/cb5fb3f7-102a-4c02-b2d9-656031cba810


## Reason of Crash
What I think is the reason of crash on first load and getting resolved after page referesh is a component `RedirectToLastSolved`
Which triggers when the url doesn't contain the `problemId` of the `track` so it goes to that component called `getLastSolved` firebase function, then update the route and push it to the first problem which like basically redirects it then slide renders.
But it might be the case that the function call hinders for some reason and app crashes but the `problemId` is pushed in the url so on refreshes it already has `problemId` so it won't call `getLastSolved` and renders the page. 
MY REASONING MIGHT BE WRONG

## Too Many Functions calls
As you can see in the Before video Whenever the slide is rendered it also call 6-10 `getProblem` function even after the pages are cache it still make those calls which is used inside the **JUMP TO** feature.

## Changes I Made
- To tackle that redirecting and avoiding that `getLastSolved` function call I evaluate the `Landing Screen` where we set the link component only with `trackId`
```
<Link className="max-w-screen-md w-full" href={`/tracks/${t.id}`}>
  <TrackCard track={t} />
</Link>
```
but the tracks also have `problems` array in them which contains all the problemIds so what I did is 
```
<Link className="max-w-screen-md w-full" href={`/tracks/${t.id}/${t.problems[0]}`}>
  <TrackCard track={t} />
</Link>
```
I added the first problem to the link because every time it clicks it should show the first slide.

- To remove unnecessary calls to firebase function `getProblem` which is used in the `PageToggle` component, I remove the logic of getting all problems and move it to the server inside `page.tsx` of track folder where I fetched all the problems on server and passes it down to the `pageToggle` component which make it look like prop drilling but there's no other way, it's not like that i can use a contextApi or recoil to store it on the backend and directly fetches in the `PageToggle` component and also we're passing down the `track` props so why not `allProblems` array which SIGNIFICANTLY  reduces the network request 

You can see the number of request went down aggressively like in some pages it went down from 33 to 6-8 and in after caching it went down from 8-10 to 0-1, although in the first time render it shows the transferred and resources are similar but after cache it makes the difference 

