### PR TITLE
Fix: Requesting notion css on every slide's tracks

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,13 @@ import { cn } from "@repo/ui/utils";
 import { Auth } from "../components/Auth";
 import { Providers, ThemeProvider } from "../components/Providers";
 
+// core styles shared by all of react-notion-x (required)
+import "react-notion-x/src/styles.css";
+// used for code syntax highlighting (optional)
+import "prismjs/themes/prism-tomorrow.css";
+// used for rendering equations (optional)
+import "katex/dist/katex.min.css";
+
 const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",

--- a/packages/ui/src/NotionRenderer.tsx
+++ b/packages/ui/src/NotionRenderer.tsx
@@ -1,15 +1,6 @@
 "use client";
 import { NotionRenderer as NotionRendererLib } from "react-notion-x";
 import { Code } from "react-notion-x/build/third-party/code";
-
-// core styles shared by all of react-notion-x (required)
-import "react-notion-x/src/styles.css";
-
-// used for code syntax highlighting (optional)
-import "prismjs/themes/prism-tomorrow.css";
-
-// used for rendering equations (optional)
-import "katex/dist/katex.min.css";
 import { useTheme } from "next-themes";
 
 // Week-4-1-647987d9b1894c54ba5c822978377910


### PR DESCRIPTION
# Pull Request Description
This pull request removes css fetch call every time a new track is load

### Before:
https://github.com/code100x/daily-code/assets/66407522/c2384036-34cb-404f-a188-560d4b60a555

### After:
https://github.com/code100x/daily-code/assets/66407522/87c720a6-617f-49d7-b60a-6b19e460b6e2

The notionRenderer is a client component which had the css imports So whenever prev or next button are pressed with the js css also got requested from server which is unnecessary, So I moved it up to the layout.tsx where it fetches only once and stays for all the pages

This reduces the number of call from 4 to 3 and also supports next caching 

