### PR TITLE
feat/Add cached tracks to landing page

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,3 +7,6 @@ export default async function Page(): Promise<JSX.Element> {
     </main>
   );
 }
+
+// re validates landing page tracks cached stored every hour
+export const revalidate = 3600;

--- a/apps/web/app/tracks/[...trackIds]/page.tsx
+++ b/apps/web/app/tracks/[...trackIds]/page.tsx
@@ -6,7 +6,7 @@ import db from "@repo/db/client";
 
 const notion = new NotionAPI();
 
-export async function getProblem(problemId: string | null) {
+async function getProblem(problemId: string | null) {
   if (!problemId) {
     return null;
   }
@@ -22,7 +22,7 @@ export async function getProblem(problemId: string | null) {
   }
 }
 
-export async function getTrack(trackId: string) {
+async function getTrack(trackId: string) {
   try {
     const track = await db.track.findUnique({
       where: {

--- a/apps/web/screens/Landing.tsx
+++ b/apps/web/screens/Landing.tsx
@@ -34,6 +34,7 @@ const getTracks = cache(async () => {
 
 export async function Landing() {
   const tracks = await getTracks();
+
   return (
     <div>
       <AppbarClient />

--- a/apps/web/screens/Landing.tsx
+++ b/apps/web/screens/Landing.tsx
@@ -2,8 +2,11 @@ import { TrackCard } from "@repo/ui/components";
 import Link from "next/link";
 import { AppbarClient } from "../components/AppbarClient";
 import db from "@repo/db/client";
+import { cache } from "react";
 
-async function getTracks() {
+const getTracks = cache(async () => {
+  console.log("getting tracks..");
+
   try {
     const tracks = await db.track.findMany({
       where: {
@@ -27,7 +30,7 @@ async function getTracks() {
   } catch (e) {
     return [];
   }
-}
+});
 
 export async function Landing() {
   const tracks = await getTracks();

--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -26,10 +26,12 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "ArrowRight") {
         router.push(
-          problemIndex + 1 === track.problems.length ? `` : `/tracks/${track.id}/${track.problems[problemIndex + 1]}`
+          problemIndex + 1 === track.problems.length
+            ? ``
+            : `/tracks/${track.id}/${track.problems[problemIndex + 1]?.id}`
         );
       } else if (event.key === "ArrowLeft") {
-        router.push(problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]}` : ``);
+        router.push(problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]?.id}` : ``);
       }
     };
 


### PR DESCRIPTION
As an assignment from 19.0.2, added tracks cache to landing page which re-validates once every hour. 

(also working on caching all tracks and a re-validation button on admin accounts which will allow manual re-validation) 

Had to remove named exports from apps/web/app/tracks/[...trackIds]/page.tsx because ES Lint was throwing the following error during build:  (will work on creating a separate utils file for these functions)

>Type error: Page "app/tracks/[...trackIds]/page.tsx" does not match the required types of a Next.js Page.
  "getProblem" is not a valid Page export field.


