### PR TITLE
feat/manual revalidation backend point for landing page

### DIFF
--- a/apps/web/.env.local.example
+++ b/apps/web/.env.local.example
@@ -1,0 +1,1 @@
+REVAL_PASSWORD="mytestpassword"

--- a/apps/web/app/api/revalidate/route.ts
+++ b/apps/web/app/api/revalidate/route.ts
@@ -1,0 +1,21 @@
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  const data = await req.json();
+  const password = data.password;
+  if (!password) {
+    return NextResponse.json({}, { status: 401 });
+  }
+
+  // later on this path will be received in the request to revalidate blogs as and when admin requests.
+  const path = "/";
+
+  // eslint-disable-next-line turbo/no-undeclared-env-vars
+  if (password === process.env.REVAL_PASSWORD) {
+    revalidatePath(path);
+    return NextResponse.json({ message: "re-validated" });
+  }
+
+  return NextResponse.json({}, { status: 500 });
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,3 +7,6 @@ export default async function Page(): Promise<JSX.Element> {
     </main>
   );
 }
+
+// re validates landing page tracks cached stored every hour
+export const revalidate = 3600;

--- a/apps/web/app/tracks/[...trackIds]/page.tsx
+++ b/apps/web/app/tracks/[...trackIds]/page.tsx
@@ -6,7 +6,7 @@ import db from "@repo/db/client";
 
 const notion = new NotionAPI();
 
-export async function getProblem(problemId: string | null) {
+async function getProblem(problemId: string | null) {
   if (!problemId) {
     return null;
   }
@@ -22,7 +22,7 @@ export async function getProblem(problemId: string | null) {
   }
 }
 
-export async function getTrack(trackId: string) {
+async function getTrack(trackId: string) {
   try {
     const track = await db.track.findUnique({
       where: {

--- a/apps/web/screens/Landing.tsx
+++ b/apps/web/screens/Landing.tsx
@@ -34,6 +34,7 @@ const getTracks = cache(async () => {
 
 export async function Landing() {
   const tracks = await getTracks();
+
   return (
     <div>
       <AppbarClient />

--- a/apps/web/screens/Landing.tsx
+++ b/apps/web/screens/Landing.tsx
@@ -2,8 +2,11 @@ import { TrackCard } from "@repo/ui/components";
 import Link from "next/link";
 import { AppbarClient } from "../components/AppbarClient";
 import db from "@repo/db/client";
+import { cache } from "react";
 
-async function getTracks() {
+const getTracks = cache(async () => {
+  console.log("getting tracks..");
+
   try {
     const tracks = await db.track.findMany({
       where: {
@@ -27,7 +30,7 @@ async function getTracks() {
   } catch (e) {
     return [];
   }
-}
+});
 
 export async function Landing() {
   const tracks = await getTracks();

--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -26,10 +26,12 @@ export const BlogAppbar = ({ problem, track }: { problem: Problem; track: Track 
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "ArrowRight") {
         router.push(
-          problemIndex + 1 === track.problems.length ? `` : `/tracks/${track.id}/${track.problems[problemIndex + 1]}`
+          problemIndex + 1 === track.problems.length
+            ? ``
+            : `/tracks/${track.id}/${track.problems[problemIndex + 1]?.id}`
         );
       } else if (event.key === "ArrowLeft") {
-        router.push(problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]}` : ``);
+        router.push(problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]?.id}` : ``);
       }
     };
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["**/.env.*local"],
+  "globalDependencies": ["**/.env.*local", ".env", ".env.local", "tsconfig.json"],
+  "globalEnv": ["REVAL_PASSWORD"],
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
# Added manual revalidation for the landing page cache which can be hit using a password set in .env

three things have been done in this pull request: 
- creating a cache for landing page during build time (manual revalidation possible)
- creating cache for all Blog type problems in tracks (manual revalidation not possible)
- fixing a small bug in keypress in tracks page (left and right keypresses were not working as expected)

This closes #136, #137, and #138.