### PR TITLE
Tracks are sorted in descending order and number added on thumbnail for better navigation

### DIFF
--- a/apps/web/components/utils.tsx
+++ b/apps/web/components/utils.tsx
@@ -93,3 +93,7 @@ export async function getAllCategories() {
     return [];
   }
 }
+
+export async function getSecond(tracks: any) {
+  return tracks.sort(({ createdAt: a }: any, { createdAt: b }: any) => a - b);
+}

--- a/apps/web/screens/Landing.tsx
+++ b/apps/web/screens/Landing.tsx
@@ -1,11 +1,12 @@
 import { TrackCard } from "@repo/ui/components";
 import Link from "next/link";
 import { AppbarClient } from "../components/AppbarClient";
-import { getAllCategories, getAllTracks } from "../components/utils";
+import { getAllCategories, getAllTracks, getSecond } from "../components/utils";
 import { Categories, Tracks } from "@repo/ui/components";
 
 export async function Landing() {
-  const tracks = await getAllTracks();
+  const tracks1 = await getAllTracks();
+  const tracks = await getSecond(tracks1);
   const categories = await getAllCategories();
 
   return (

--- a/packages/ui/src/TrackCard.tsx
+++ b/packages/ui/src/TrackCard.tsx
@@ -11,9 +11,12 @@ interface TrackCardProps extends Track {
   }[];
 }
 
-export function TrackCard({ track }: { track: TrackCardProps }) {
+export function TrackCard({ track, index }: { track: TrackCardProps; index: number }) {
   return (
     <Card className="max-w-screen-md w-full cursor-pointer transition-all hover:border-primary/20 shadow-lg dark:shadow-black/60">
+      <div className=" bg-red-300s flex justify-end ">
+        <div className="border rounded-md  bg-white text-black text-2xl font-semibold px-4 m-2">{index}</div>
+      </div>
       <CardHeader>
         <div className="flex flex-col sm:flex-row">
           <img src={track.image} className="min-h-[130px] sm:h-[130px] min-w-[130px] sm:w-[130px] rounded-xl"></img>

--- a/packages/ui/src/Tracks.tsx
+++ b/packages/ui/src/Tracks.tsx
@@ -29,14 +29,14 @@ export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
   return (
     <div>
       <ul className="p-8 md:20 grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-2 w-full">
-        {filteredTracks.map((t) => (
+        {filteredTracks.map((t, i) => (
           <li key={t.id} className="flex justify-center">
             {t.problems.length > 0 ? (
               <Link className="max-w-screen-md w-full block" href={`/tracks/${t.id}/${t.problems[0]?.id}`}>
-                <TrackCard track={t} />
+                <TrackCard track={t} index={filteredTracks.length - i} />
               </Link>
             ) : (
-              <TrackCard track={t} />
+              <TrackCard track={t} index={filteredTracks.length - i} />
             )}
           </li>
         ))}


### PR DESCRIPTION
1. Shorted all tracks in descending order so that the all tracks are easily found.
2. Added number on the track card for better navigation.

Solved #178 

![ScreenshotTrack](https://github.com/code100x/daily-code/assets/28997328/38454359-8e2c-4dd9-b1f8-b0a6c1b1b6e2)

- It solves this problem.

[Screencast1.webm](https://github.com/code100x/daily-code/assets/28997328/be86f63c-191f-48a9-88b0-acdfcdec9606)
