### PR TITLE
Fix :  Seeding data to track table before categories and trackCategory  table

### DIFF
--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -12,6 +12,8 @@ async function main() {
     hashID.push(seed.data.id);
   });
 
+  await Promise.all(promises);
+
   const res = await db.categories.create({
     data: {
       id: "web-development",
@@ -166,8 +168,6 @@ async function main() {
       },
     ],
   });
-
-  await Promise.all(promises);
 }
 
 main()


### PR DESCRIPTION
closes #201

In the original version of the `seed.ts` file, the script was creating records in the `categories` and `trackCategory` table before it had finished creating records in the `track` table. Because there are dependencies between these tables, this was causing issues with the seeding process.

To resolve this issue, I modified the script to wait for all promises related to the `track` table to resolve before proceeding to create records in the `categories` table. I did this by adding an `await Promise.all(promises)` line after the `forEach` loop that creates the `track` records.

This ensures that all `track` records are created before we start creating `categories` records, which prevents the foreign key constraint errors we were seeing previously.