### PR TITLE
Addresses issues #196 & #210

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,37 @@
 # Quick Setup Locally
 
 > Install the Dependencies
+
 ```
 cd daily-code
 yarn install
 ```
+
 > Copy the env example
+
 ```
 cd /packages/db
 cp .env.example .env
 ```
->Update the .env file with the database url
+
+> Update the .env file with the database url
 
 > Migrate and the Database
+
 ```
 npx prisma migrate dev
 npx prisma db seed
 ```
+
+> If previous commands fail, try these; Otherwise, skip.
+
+```
+yarn prisma migrate dev
+yarn prisma db seed
+```
+
 > Run locally
+
 ```
 cd ../..
 yarn run dev

--- a/packages/ui/src/TrackCard.tsx
+++ b/packages/ui/src/TrackCard.tsx
@@ -25,7 +25,7 @@ export function TrackCard({ track }: { track: TrackCardProps }) {
             <div>{track.description}</div>
             <CardDescription>
               {track.categories.map((item) => {
-                return <div>{item.category.category}</div>;
+                return <div key={item.category.id}>{item.category.category}</div>;
               })}
             </CardDescription>
           </div>


### PR DESCRIPTION
This is a readme.md change which adds the yarn alternative commands for migrating, seeding via prisma. 
This addresses the issue #196 which I faced while setting it up on my windows machine. 
The issue might have occurred due some incompatibility of yarn workspaces using npx.