### PR TITLE
Fix : categories menubar overflow 

### DIFF
--- a/packages/ui/app/globals.css
+++ b/packages/ui/app/globals.css
@@ -109,3 +109,15 @@
   /* Optionally add box-shadow based on your design */
   box-shadow: 0 0 5px #5d5c5d;
 }
+
+
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+}

--- a/packages/ui/src/Categories.tsx
+++ b/packages/ui/src/Categories.tsx
@@ -2,6 +2,7 @@
 import { Button } from "./shad/ui/button";
 import { useRecoilState } from "recoil";
 import { category } from "@repo/store";
+import { cn } from "../lib/utils";
 
 export const Categories = ({ categories }: { categories: { category: string }[] }) => {
   function handleFilterButton(category: string) {
@@ -19,7 +20,9 @@ export const Categories = ({ categories }: { categories: { category: string }[] 
           key={category.category}
           variant="ghost"
           onClick={() => handleFilterButton(category.category)}
-          className={selectedCategory == category.category ? "bg-gray-100 dark:bg-slate-700" : ""}
+          className={cn("mx-1", {
+            "bg-gray-100 dark:bg-slate-700": selectedCategory == category.category,
+          })}
         >
           {category.category}
         </Button>

--- a/packages/ui/src/Categories.tsx
+++ b/packages/ui/src/Categories.tsx
@@ -13,7 +13,7 @@ export const Categories = ({ categories }: { categories: { category: string }[] 
   }
   const [selectedCategory, setSelectedCategory] = useRecoilState(category);
   return (
-    <div className="flex justify-evenly mx-auto border-2 rounded-full py-1 w-2/3">
+    <div className="flex justify-evenly mx-auto border-2 rounded-full py-1 w-2/3  overflow-auto scroll-smooth no-scrollbar">
       {categories.map((category) => (
         <Button
           key={category.category}


### PR DESCRIPTION
## Description
On smaller screens and when the number of categories is large, the categories menu overflows from its container. This causes some categories to be inaccessible and disrupts the layout of the page.

## Proposed Solution
To fix this issue, I propose adding the `overflow-auto`, `scroll-smooth`, and `no-scrollbar` classes to the categories container. This will allow the container to scroll horizontally when the categories overflow, ensuring all categories are accessible. The  `no-scrollbar` class will hide the scrollbar to maintain a clean look. i added it in global.css

## Additional context
This issue was identified while testing the application on smaller screen sizes and with a large number of categories.

## After Fix : 

https://github.com/code100x/daily-code/assets/64027486/deac5a3c-d429-4640-9ca5-db692265795c

