### PR TITLE
fix: Hydration failed error

### DIFF
--- a/packages/ui/src/shad/ui/card.tsx
+++ b/packages/ui/src/shad/ui/card.tsx
@@ -21,7 +21,7 @@ CardTitle.displayName = "CardTitle";
 
 const CardDescription = forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
   ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+    <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
   )
 );
 CardDescription.displayName = "CardDescription";


### PR DESCRIPTION
fixes: #211
the error doesn't show now and was caused because of a `<p>` tag which was located in "daily-code/packages/ui/src/shad/ui/card.tsx"
this happens because We use components to build the React-based websites, These components are made using HTML tags. It is very important not to nest the same HTML elements.