### PR TITLE
Added pager to show limited Tracks in single page

### DIFF
--- a/packages/ui/src/Tracks.tsx
+++ b/packages/ui/src/Tracks.tsx
@@ -1,10 +1,10 @@
 "use client";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { TrackCard } from "@repo/ui/components";
 import { category } from "@repo/store";
 import { Track, Problem } from "@prisma/client";
 import { useRecoilValue } from "recoil";
-import { useEffect, useState } from "react";
 
 interface Tracks extends Track {
   problems: Problem[];
@@ -18,21 +18,32 @@ interface Tracks extends Track {
 
 export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
   const selectedCategory = useRecoilValue(category);
-  const [filteredTracks, setFilteredTracks] = useState(tracks);
-  const filtereTracks = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const tracksPerPage = 10;
+
+  const filterTracks = () => {
     let filteredTracks = tracks;
     if (selectedCategory.length > 0) {
       filteredTracks = filteredTracks.filter((t) => t.categories.some((c) => c.category.category === selectedCategory));
     }
-    setFilteredTracks(filteredTracks);
+    return filteredTracks;
   };
+
+  const totalTracks = filterTracks().length;
+  const indexOfLastTrack = currentPage * tracksPerPage;
+  const indexOfFirstTrack = indexOfLastTrack - tracksPerPage;
+  const currentTracks = filterTracks().slice(indexOfFirstTrack, indexOfLastTrack);
+
   useEffect(() => {
-    filtereTracks();
+    setCurrentPage(1); // Reset page number when category changes
   }, [selectedCategory]);
+
+  const paginate = (pageNumber: number) => setCurrentPage(pageNumber);
+
   return (
     <div>
       <ul className="p-8 md:20 grid grid-cols-1 gap-x-6 gap-y-8 lg:grid-cols-2 w-full">
-        {filteredTracks.map((t) => (
+        {currentTracks.map((t) => (
           <li key={t.id} className="flex justify-center">
             {t.problems.length > 0 ? (
               <Link className="max-w-screen-md w-full block" href={`/tracks/${t.id}/${t.problems[0]?.id}`}>
@@ -44,6 +55,19 @@ export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
           </li>
         ))}
       </ul>
+      {totalTracks > tracksPerPage && (
+        <div className="flex justify-center py-4 mb-8">
+          {Array.from({ length: Math.ceil(totalTracks / tracksPerPage) }, (_, i) => (
+            <button
+              key={i}
+              onClick={() => paginate(i + 1)}
+              className={`mx-1 px-3 py-1 rounded ${i + 1 === currentPage ? "bg-blue-500 text-white" : "bg-gray-300"}`}
+            >
+              {i + 1}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Before - 
<img width="1470" alt="Screenshot 2024-04-13 at 9 10 50 PM" src="https://github.com/code100x/daily-code/assets/67222925/fb75c199-d8ce-4c4d-8e28-f5e4d1e22568">
Update - 
Pager would only only shows on category where tracks are more than 10 

<img width="1470" alt="Screenshot 2024-04-13 at 9 12 19 PM" src="https://github.com/code100x/daily-code/assets/67222925/0717e1ae-12cf-49ef-8eba-51dbe4a1a119">
