### PR TITLE
feat:  #204 enhance tab responsiveness and add select menu for smaller screens

### DIFF
--- a/packages/ui/app/globals.css
+++ b/packages/ui/app/globals.css
@@ -91,16 +91,18 @@
 
 /* Horizontal Scroll Bar */
 ::-webkit-scrollbar:horizontal {
-  height: 8px;
+  height: 2px;
+  display: none;
 }
 
 ::-webkit-scrollbar-thumb:horizontal {
-  background-color: rgb(93, 92, 93, 0.8); 
+  background-color: rgba(136, 133, 136, 0.8); 
   border-radius: 4px;
+  
 }
 
 ::-webkit-scrollbar-track:horizontal {
-  background-color: rgb(31, 41, 55, 0.8); 
+  background-color: rgba(167, 168, 169, 0.8); 
 }
 
 /* Optional: Add hover effect */

--- a/packages/ui/src/Categories.tsx
+++ b/packages/ui/src/Categories.tsx
@@ -2,6 +2,7 @@
 import { Button } from "./shad/ui/button";
 import { useRecoilState } from "recoil";
 import { category } from "@repo/store";
+import useWindowSize from "./hooks/useWindowSize";
 
 export const Categories = ({ categories }: { categories: { category: string }[] }) => {
   function handleFilterButton(category: string) {
@@ -11,19 +12,39 @@ export const Categories = ({ categories }: { categories: { category: string }[] 
       setSelectedCategory(category);
     }
   }
+  const { windowWidth } = useWindowSize();
+
   const [selectedCategory, setSelectedCategory] = useRecoilState(category);
   return (
-    <div className="flex justify-evenly mx-auto border-2 rounded-full py-1 w-2/3">
-      {categories.map((category) => (
-        <Button
-          key={category.category}
-          variant="ghost"
-          onClick={() => handleFilterButton(category.category)}
-          className={selectedCategory == category.category ? "bg-gray-100 dark:bg-slate-700" : ""}
-        >
-          {category.category}
-        </Button>
-      ))}
+    <div className="flex justify-center px-4">
+      {windowWidth > 640 ? (
+        <div className="flex justify-evenly  border-2 rounded-full py-1 lg:w-2/3 md:w-full overflow-x-auto scroll-p-0 sm:mx-8">
+          {categories.map((category) => (
+            <Button
+              key={category.category}
+              variant="ghost"
+              onClick={() => handleFilterButton(category.category)}
+              className={selectedCategory == category.category ? "bg-gray-100 dark:bg-slate-700 z-0" : ""}
+            >
+              {category.category}
+            </Button>
+          ))}
+        </div>
+      ) : (
+        <>
+          <select
+            className=" text-gray-900 text-sm rounded-full outline-none  focus:ring-slate-500 focus:border-slate-700 block w-full p-2.5 dark:bg-black  dark:border-gray-700 border-2 dark:placeholder-black dark:text-white dark:focus:ring-slate-500 dark:focus:border-slate-500"
+            value={selectedCategory}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleFilterButton(e.target.value)}
+          >
+            {categories.map((category) => (
+              <option key={category.category} value={category.category}>
+                {category.category}
+              </option>
+            ))}
+          </select>
+        </>
+      )}
     </div>
   );
 };

--- a/packages/ui/src/hooks/useWindowSize.ts
+++ b/packages/ui/src/hooks/useWindowSize.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from "react";
+
+const useWindowSize = () => {
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const [windowHeight, setWindowHeight] = useState(window.innerHeight);
+
+  // Event handler function to update the state variables when the window is resized
+  const handleResize = () => {
+    setWindowWidth(window.innerWidth);
+    setWindowHeight(window.innerHeight);
+  };
+
+  useEffect(() => {
+    // Event listener for resize event
+    window.addEventListener("resize", handleResize);
+
+    // Cleanup function to remove the event listener when the component unmounts
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  // Return the current window width and height
+  return { windowWidth, windowHeight };
+};
+
+export default useWindowSize;


### PR DESCRIPTION
In this pull request, I've improved the responsiveness of the Tabs component. Previously, on smaller screens, the outer line was shorter than the span of the tabs, causing a visual imbalance. Here's how I've addressed this issue:

- Horizontal Scroll for Small Screens: Tabs are now horizontally scrollable, ensuring a better user experience on small screens.
- Mobile Screen Enhancement: Added a styled Select menu for mobile screens for better navigation.

Check out the attached demo for a preview of these updates. Let me know if you have any questions.

Thank you!

https://github.com/code100x/daily-code/assets/63789293/e51f8e4e-86c7-445a-9c44-a340f0ee9cd0





