### PR TITLE
fix /tracks related routing bug

### DIFF
--- a/apps/web/app/tracks/[...trackIds]/page.tsx
+++ b/apps/web/app/tracks/[...trackIds]/page.tsx
@@ -1,6 +1,6 @@
 import { RedirectToLastSolved } from "../../../components/RedirectToLastSolved";
 import { NotionAPI } from "notion-client";
-import { redirect } from "next/navigation";
+import { redirect, notFound } from "next/navigation";
 import { getAllTracks, getProblem, getTrack } from "../../../components/utils";
 import { cache } from "react";
 import { LessonView } from "../../../components/LessonView";
@@ -40,7 +40,7 @@ export default async function TrackComponent({ params }: { params: { trackIds: s
   //@ts-ignore
   const [problemDetails, trackDetails] = await Promise.all([getProblem(problemId || null), getTrack(trackId)]);
 
-  if (!problemId) {
+  if (trackDetails && !problemId) {
     return <RedirectToLastSolved trackId={trackId} />;
   }
 
@@ -61,5 +61,7 @@ export default async function TrackComponent({ params }: { params: { trackIds: s
         />
       </div>
     );
+  } else {
+    notFound();
   }
 }

--- a/apps/web/components/RedirectToLastSolved.tsx
+++ b/apps/web/components/RedirectToLastSolved.tsx
@@ -10,12 +10,9 @@ export const RedirectToLastSolved = ({ trackId }: { trackId: string }) => {
   const router = useRouter();
 
   useEffect(() => {
-    const problemId = getFirstProblemForTrack(trackId);
-    try {
+    getFirstProblemForTrack(trackId).then((problemId) => {
       router.replace(`/tracks/${trackId}/${problemId}`);
-    } catch (e) {
-      console.error(e);
-    }
+    });
   }, [trackId]);
 
   return (


### PR DESCRIPTION
[dailycode_track_fix.webm](https://github.com/code100x/daily-code/assets/45840495/157cb223-63fa-4e2e-ba6f-813dc23da725)

### PR Fixes:
- 1 if user visits `/tracks/<track>/<problem>` where track or problem is invalid we will properly show the 404 error page (in prod nothing was done just a blank page was shown)
- 2 if user visits `/tracks/<track>` we correctly resolve and redirect to `/tracks/<track>/<problem>` (in prod we didnt resolve the promise and hence redirected to `/tracks/<track>/[object%20Promise]`)

Resolves #278 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
