### PR TITLE
Make navbar of pages more responsive for smaller screen

### DIFF
--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -106,7 +106,7 @@ export const BlogAppbar = ({
         </div>
 
         <p className="flex-1 justify-center items-center font-medium ml-2 hidden md:flex">
-          {problem.title} ({problemIndex + 1} / {track.problems.length})
+          {track.title} ({problemIndex + 1} / {track.problems.length})
         </p>
         {problem.type === "Code" && problem.problemStatement && <Codebar problemStatement={problem.problemStatement} />}
         <div className="flex space-x-2 mb-2">
@@ -186,7 +186,7 @@ export const BlogAppbar = ({
       </div>
 
       <p className="flex-1 justify-center items-center font-medium ml-2 flex md:hidden pt-2 border-t w-full text-center bg-opacity-60">
-        {problem.title} ({problemIndex + 1} / {track.problems.length})
+        {track.title} ({problemIndex + 1} / {track.problems.length})
       </p>
     </div>
   );

--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -109,21 +109,33 @@ export const BlogAppbar = ({
           {problem.title} ({problemIndex + 1} / {track.problems.length})
         </p>
         {problem.type === "Code" && problem.problemStatement && <Codebar problemStatement={problem.problemStatement} />}
-        <div className="mb-2">
-          <PageToggle allProblems={track.problems} track={track} />
-        </div>
-
         <div className="flex space-x-2 mb-2">
+          <div className="mb-2">
+            <PageToggle allProblems={track.problems} track={track} />
+          </div>
           <Link
             prefetch={true}
             href={problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]!.id}` : ``}
             style={{ cursor: problemIndex !== 0 ? "pointer" : "not-allowed" }}
           >
-            <Button variant="outline" className="ml-2 bg-black text-white" disabled={problemIndex !== 0 ? false : true}>
+            <Button
+              variant="outline"
+              className="ml-2 bg-black text-white md:flex hidden"
+              disabled={problemIndex !== 0 ? false : true}
+            >
               <div className="pr-2">
                 <ChevronLeftIcon />
               </div>
               Prev
+            </Button>
+            <Button
+              variant="outline"
+              className=" bg-black text-white md:hidden block"
+              disabled={problemIndex !== 0 ? false : true}
+            >
+              <div>
+                <ChevronLeftIcon />
+              </div>
             </Button>
           </Link>
 
@@ -138,7 +150,7 @@ export const BlogAppbar = ({
           >
             <Button
               variant="outline"
-              className="bg-black text-white"
+              className="bg-black text-white md:flex hidden"
               disabled={problemIndex + 1 !== track.problems.length ? false : true}
             >
               Next
@@ -146,12 +158,26 @@ export const BlogAppbar = ({
                 <ChevronRightIcon />
               </div>
             </Button>
+            <Button
+              variant="outline"
+              className="bg-black text-white md:hidden block"
+              disabled={problemIndex + 1 !== track.problems.length ? false : true}
+            >
+              <div>
+                <ChevronRightIcon />
+              </div>
+            </Button>
           </Link>
           <ModeToggle />
           <Link href={`/pdf/${track.id}/${track.problems[problemIndex]!.id}`} target="_blank">
-            <Button variant="outline" className="ml-2 bg-black text-white">
+            <Button variant="outline" className="ml-2 bg-black text-white md:flex hidden">
               Download
               <div className="pl-2">
+                <DownloadIcon />
+              </div>
+            </Button>
+            <Button variant="outline" className=" bg-black text-white md:hidden block">
+              <div>
                 <DownloadIcon />
               </div>
             </Button>

--- a/packages/ui/src/PageToggle.tsx
+++ b/packages/ui/src/PageToggle.tsx
@@ -12,12 +12,19 @@ export function PageToggle({ allProblems, track }: { allProblems: Problem[]; tra
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline">
-          Jump To
-          <div className="pl-2">
-            <ArrowTopRightIcon />
-          </div>
-        </Button>
+        <div>
+          <Button variant="outline" className="md:flex hidden">
+            Jump To
+            <div className="pl-2">
+              <ArrowTopRightIcon />
+            </div>
+          </Button>
+          <Button variant="outline" className="md:hidden block">
+            <div>
+              <ArrowTopRightIcon />
+            </div>
+          </Button>
+        </div>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className={cn("overflow-y-auto max-h-[80vh]")}>
         {allProblems.map((problem: { id: string; title: string }, index: number) => (


### PR DESCRIPTION
### PR Fixes:
- 1 Make navbar more responsive for smaller screen for better readability 

Resolves #178 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

-PR #182 created by me has same changes but now it has merge conflicts so creating this new and removing that

- Before
![Screenshot_Before](https://github.com/code100x/daily-code/assets/28997328/263f94e8-a878-4110-b01a-2616e27a22e1)

- After
![Screenshot_After](https://github.com/code100x/daily-code/assets/28997328/a7a3af83-c0c2-4ee8-8e28-125cc6bef5d7)


# --------------------------------  New Commit ------------------------------- 

**Change navbar title from page title to track title**
1. As the page title is visible below the navbar title
2. After some time when we continue we forgot that what track we are at 

- Before

![Screenshot 11old](https://github.com/code100x/daily-code/assets/28997328/aeeb34c8-b035-499c-8a43-78fd88b2bf24)

- Now
![Screenshot 11new](https://github.com/code100x/daily-code/assets/28997328/755004bf-8198-4ad6-9261-6eec59964a46)
