### PR TITLE
fix: touch event in selecting component in catagories, causing bubble problem

### DIFF
--- a/packages/ui/src/Categories.tsx
+++ b/packages/ui/src/Categories.tsx
@@ -56,7 +56,14 @@ const SelectCategory = ({ categories, selectedCategory, handleCategoryChange }: 
         <SelectTrigger className="w-[250px]">
           <SelectValue placeholder={selectedCategory || "All Categories"}></SelectValue>
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent
+        ref={(ref)=>{
+          if(!ref) return;
+          ref.ontouchstart = (e)=>{
+            e.preventDefault();
+          }
+        }}
+        >
           {categories.map((category) => (
             <SelectItem value={category.category} key={category.category}>
               {category.category}


### PR DESCRIPTION
Resolves  #292 

## PR FIX : 
  - When the user selected an option, the mobile event bubbled up to the nearby link causing unintentional navigation.
     this  problem is with shadcn UI , select component.


## Before fix:

https://github.com/code100x/daily-code/assets/64027486/716c86e0-8e5f-40c5-95e3-3362424c27a5


## After fix :
        
https://github.com/code100x/daily-code/assets/64027486/468ec46e-de20-43d3-83b3-b9132030e701



### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue
