### PR TITLE
Fix mobile screen code block overflow issue

### DIFF
--- a/packages/ui/src/CodeBlock.tsx
+++ b/packages/ui/src/CodeBlock.tsx
@@ -14,10 +14,10 @@ export default function CodeBlock({ block }: { block: any }) {
   }, []);
 
   return (
-    <div>
-      <pre className={styles.code_block}>
+    <div className="max-w-full overflow-auto">
+      <pre className={`${styles.code_block} px-4 sm:px-6 md:px-8 relative`}>
         <code className="language-javascript">{code}</code>
-        <div className={styles.copy_block}>
+        <div className={`${styles.copy_block} absolute top-0 right-0`}>
           <button
             className={styles.copy_button}
             onClick={() => {


### PR DESCRIPTION
 

@hkirat The previous pull request (#289 ) was closed because that has some yarn.lock conflict.

- This pr fixes the codeblock overflowing issue.
- In this I have implemented CSS adjustments to ensure code blocks are properly contained within the viewport on mobile devices.

Resolves #288 

![chrome-capture-2024-4-16](https://github.com/code100x/daily-code/assets/81159771/e3038d8f-a6c6-4db3-8323-186a3a2d0a4a)

- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
