### PR TITLE
fix: Makes categories btn capsule-shaped

### DIFF
--- a/packages/ui/src/Categories.tsx
+++ b/packages/ui/src/Categories.tsx
@@ -76,7 +76,9 @@ const ButtonCategory = ({ categories, selectedCategory, handleCategoryChange }: 
           key={category.category}
           variant="ghost"
           onClick={() => handleCategoryChange(category.category)}
-          className={selectedCategory == category.category ? "bg-gray-100 dark:bg-slate-700" : ""}
+          className={
+            selectedCategory == category.category ? "bg-gray-100 dark:bg-slate-700 rounded-full" : "rounded-full"
+          }
         >
           {category.category}
         </Button>


### PR DESCRIPTION
### PR Fixes:
- 1 Makes the categories buttons on the category-filter-bar Capsule shape
![image](https://github.com/code100x/daily-code/assets/115286446/79167bcb-cd97-4b9f-9456-4b5fae00a4bc)

Resolves #306  

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
