### PR TITLE
added a All categories button/select compoent in the  landing page .it appears only when the user is on the different track

### DIFF
--- a/packages/ui/src/Categories.tsx
+++ b/packages/ui/src/Categories.tsx
@@ -18,7 +18,7 @@ export const Categories = ({ categories }: { categories: Category[] }) => {
   const [selectedCategory, setSelectedCategory] = useRecoilState(category);
 
   const handleCategoryChange = (category: string) => {
-    if (category === selectedCategory) {
+    if (category === selectedCategory || category === "All Categories") {
       setSelectedCategory("");
     } else {
       setSelectedCategory(category);
@@ -54,7 +54,9 @@ const SelectCategory = ({ categories, selectedCategory, handleCategoryChange }: 
         }}
       >
         <SelectTrigger className="w-[250px]">
-          <SelectValue placeholder={selectedCategory || "All Categories"}></SelectValue>
+          <SelectValue placeholder={selectedCategory || "All Categories"}>
+            {selectedCategory || "All Categories"}
+          </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {categories.map((category) => (
@@ -62,6 +64,7 @@ const SelectCategory = ({ categories, selectedCategory, handleCategoryChange }: 
               {category.category}
             </SelectItem>
           ))}
+          {selectedCategory && <SelectItem value="All Categories">All Categories</SelectItem>}
         </SelectContent>
       </Select>
     </div>

--- a/packages/ui/src/Categories.tsx
+++ b/packages/ui/src/Categories.tsx
@@ -74,6 +74,15 @@ const SelectCategory = ({ categories, selectedCategory, handleCategoryChange }: 
 const ButtonCategory = ({ categories, selectedCategory, handleCategoryChange }: CategoryProps) => {
   return (
     <div className="flex justify-evenly mx-auto border-2 rounded-full py-1 w-2/3">
+      {selectedCategory && (
+        <Button
+          variant="ghost"
+          onClick={() => handleCategoryChange("All Categories")}
+          className={selectedCategory == "" ? "bg-gray-100 dark:bg-slate-700" : ""}
+        >
+          All Categories
+        </Button>
+      )}
       {categories.map((category) => (
         <Button
           key={category.category}


### PR DESCRIPTION
**This pull request makes the following changes**
*Fixes Isuue #322 


i have made a logic that runs only when the user is on the other tracks like dsa or web development only then they can see the All Categories button and if the user is on All categories the button did not render 

aslo it will work on both button component and select component

**Checklist**
- [x] I have created an issue for this solution i am submitting
- [x]  i created a new branch from the correct branch and made my changes in the new branch created 
- [x] i have linked the issue i worked on to this pull request submitted by me
- [x] i have run the test and everytype of checks that my mind can think of

 i have Just changed the packages/ui/src/Categories.tsx 
with the minimal change in the file helped me to crete it like .
after my changes it should look like this and fully working



First change when we are on the All Categories the all categories button and select 

Button Component -
![Screenshot from 2024-04-22 01-29-02](https://github.com/code100x/daily-code/assets/133818254/b1c77ba3-7b5d-4293-966d-e05fb121fde0)

 Select Coomponent -
![Screenshot from 2024-04-22 01-34-54](https://github.com/code100x/daily-code/assets/133818254/158ed023-6095-476b-bc02-ae7c04c00ced)

After we are on othere route the All Categories appear on both  select/button component

Button Component -
![Screenshot from 2024-04-22 01-29-14](https://github.com/code100x/daily-code/assets/133818254/a9e711df-edd1-4fa8-8c82-58f649f8bdd5)

Select Component-
![Screenshot from 2024-04-22 01-36-35](https://github.com/code100x/daily-code/assets/133818254/b511d745-4e4d-4187-aa04-973c8c6013ed)

Closes Issue #322 
Also this is my second pull request after contributing to chess please check it out 



