### PR TITLE
fixed scrollableContainerRef missing declaration that causes runtime error &

### DIFF
--- a/packages/ui/src/SearchDialog.tsx
+++ b/packages/ui/src/SearchDialog.tsx
@@ -11,8 +11,7 @@ import Link from "next/link";
 
 export function SearchDialog({ tracks }: { tracks: (Track & { problems: Problem[] })[] }) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const 
-  = useRef<HTMLDivElement>(null);
+  const scrollableContainerRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState("");
   const [searchTracks, setSearchTracks] = useState(tracks);
   const [selectedIndex, setSelectedIndex] = useState(-1);


### PR DESCRIPTION
### PR Fixes:
- `/daily-code/packages/ui/src/SearchDialog.tsx` component missing the `scrollableContainerRef` declaration & being used elsewhere that cause the compile failure. Added the proper declaration to prevent the compilation failure.

![image](https://github.com/code100x/daily-code/assets/81454473/2399863d-1c73-4124-a42b-35f8c03fc996)


Resolves #[Issue Number if there] 


### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
