### PR TITLE
fix: searchdialog - undefined scroll ref

### DIFF
--- a/packages/ui/src/SearchDialog.tsx
+++ b/packages/ui/src/SearchDialog.tsx
@@ -11,8 +11,7 @@ import Link from "next/link";
 
 export function SearchDialog({ tracks }: { tracks: (Track & { problems: Problem[] })[] }) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const 
-  = useRef<HTMLDivElement>(null);
+  const scrollableContainerRef= useRef<HTMLDivElement>(null);
   const [input, setInput] = useState("");
   const [searchTracks, setSearchTracks] = useState(tracks);
   const [selectedIndex, setSelectedIndex] = useState(-1);


### PR DESCRIPTION
### PR Fixes:
- Undefined scrollableContainerRef: The code previously referenced a variable named scrollableContainerRef for scrolling functionality, but it wasn't defined. I fixed that by defining it.

- Resolves:  #351 
- Now website is working fine & error has gone
![image](https://github.com/code100x/daily-code/assets/80579894/e03854bb-05d7-4508-9e1b-379cca744c0d)

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure you there is no similar/duplicate pull request regarding the same issue
