### PR TITLE
Feat(371) - Tracks Behind Auth

### DIFF
--- a/packages/ui/src/BlogAppbar.tsx
+++ b/packages/ui/src/BlogAppbar.tsx
@@ -10,6 +10,7 @@ import { PageToggle } from "./PageToggle";
 import { useRouter } from "next/navigation";
 import UserAccountDropDown from "./UserAccountDropDown";
 import { Codebar } from "./code/Codebar";
+import { useSession } from "next-auth/react";
 
 export const BlogAppbar = ({
   problem,
@@ -36,6 +37,8 @@ export const BlogAppbar = ({
   }
 
   const router = useRouter();
+  const session = useSession();
+  const isAuthenticated = session.status === 'authenticated' && session.data !== null;
 
   const [prevScrollPos, setPrevScrollPos] = useState(0);
   const [visible, setVisible] = useState(true);
@@ -170,6 +173,7 @@ export const BlogAppbar = ({
             </Button>
           </Link>
           <ModeToggle />
+          {isAuthenticated && (
           <Link href={`/pdf/${track.id}/${track.problems[problemIndex]!.id}`} target="_blank">
             <Button variant="outline" className="ml-2 bg-black text-white md:flex hidden">
               Download
@@ -182,7 +186,7 @@ export const BlogAppbar = ({
                 <DownloadIcon />
               </div>
             </Button>
-          </Link>
+          </Link>)}
           <UserAccountDropDown />
         </div>
       </div>

--- a/packages/ui/src/NotionRenderer.tsx
+++ b/packages/ui/src/NotionRenderer.tsx
@@ -3,12 +3,16 @@ import { NotionRenderer as NotionRendererLib } from "react-notion-x";
 // import { Code } from "react-notion-x/build/third-party/code";
 import CodeBlock from "./CodeBlock";
 import { useTheme } from "next-themes";
+import { useSession } from "next-auth/react";
+import RedirectToLoginCard from "./RedirectToLoginCard";
 
 // Week-4-1-647987d9b1894c54ba5c822978377910
 export const NotionRenderer = ({ recordMap }: { recordMap: any }) => {
   const { resolvedTheme } = useTheme();
-
-  return (
+  const session = useSession();
+  const isAuthenticated = session.status === 'authenticated' && session.data !== null;
+  
+  return isAuthenticated ? (
     <div className="w-full">
       <style>
         {`
@@ -32,5 +36,7 @@ export const NotionRenderer = ({ recordMap }: { recordMap: any }) => {
         />
       </div>
     </div>
+  ) : (
+    <RedirectToLoginCard />
   );
 };

--- a/packages/ui/src/RedirectToLoginCard.tsx
+++ b/packages/ui/src/RedirectToLoginCard.tsx
@@ -11,13 +11,13 @@ const RedirectToLoginCard = () => {
     router.push("/auth");
   };
   return (
-    <Card className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 shadow-lg w-1/4">
+    <Card className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 shadow-lg w-1/2">
       <CardHeader>
         <CardTitle>Login to access the content</CardTitle>
         <CardDescription>You'll be redirected back to this page after login</CardDescription>
       </CardHeader>
       <CardContent className="px-4">
-        <Button className="w-1/2 mt-4" onClick={redirectToLogin}>
+        <Button className="w-full mt-4" onClick={redirectToLogin}>
           Go to Login Page
         </Button>
       </CardContent>

--- a/packages/ui/src/TrackCard.tsx
+++ b/packages/ui/src/TrackCard.tsx
@@ -1,8 +1,9 @@
 import { Button } from "./shad/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "./shad/ui/card";
 
-import { ArrowRightIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+import { ArrowRightIcon, ChevronRightIcon, LockClosedIcon } from "@radix-ui/react-icons";
 import { Track, Problem } from "@prisma/client";
+import { useSession } from "next-auth/react";
 
 interface TrackCardProps extends Track {
   problems: Problem[];
@@ -15,7 +16,9 @@ interface TrackCardProps extends Track {
 }
 
 export function TrackCard({ track }: { track: TrackCardProps }) {
-  return (
+  const session = useSession();
+  const isAuthenticated = session.status === 'authenticated' && session.data !== null;
+  return ( 
     <Card className="max-w-screen-md w-full cursor-pointer transition-all hover:border-primary/20 shadow-lg dark:shadow-black/60">
       <CardHeader>
         <div className="flex flex-col sm:flex-row">
@@ -33,9 +36,18 @@ export function TrackCard({ track }: { track: TrackCardProps }) {
         <div className="flex justify-between">
           <h3 className="flex flex-col justify-center">{track.problems.length} Lessons</h3>
           <Button size={"lg"} className="flex items-center justify-center group">
-            Explore
-            <ChevronRightIcon className="pl-1 h-4 w-4 group-hover:translate-x-1 group-hover:hidden mt-[0.15rem] transition-all duration-150" />
-            <ArrowRightIcon className="pl-1 h-4 w-4 hidden group-hover:block mt-[0.15rem] transition-all duration-150" />
+            {isAuthenticated ? (
+              <>
+                Explore
+                <ChevronRightIcon className="pl-1 h-4 w-4 group-hover:translate-x-1 group-hover:hidden mt-[0.15rem] transition-all duration-150" />
+                <ArrowRightIcon className="pl-1 h-4 w-4 hidden group-hover:block mt-[0.15rem] transition-all duration-150" />
+              </>
+            ) : (
+              <>
+                <LockClosedIcon className="mr-1" />
+                Locked
+              </>
+            )}
           </Button>
         </div>
       </CardHeader>


### PR DESCRIPTION
### PR Fixes:
@hkirat 
- 1 Visual Changes to RedirectToLogin page. In smaller screen text was getting mushed up. Sorted that out. 
- 2 User won't be able to access the track's content but will be able to see the cards (title and description).  IMO this approach seems better than hiding all the tracks behind auth. Unless hiding the tracks is important rather than just preventing access to them. 
- 3 the explore button gets replaced with a Locked button with a lock sign. 
- 4 If the user goes into individual tracks(even through an URL), they are shown the RedirectToLogin (pre-existing) component. 
- 5 In AppBar, the Download button gets disabled when user is not authenticated. 

Locked buttons
![image](https://github.com/code100x/daily-code/assets/53070244/cee0c3d0-c71e-4614-8a88-f834fa86217c)
RedirectToLogin Page and Hidden Download Button
![image](https://github.com/code100x/daily-code/assets/53070244/566ef475-a5d8-45ad-86a7-9d3738d5ba7f)
Mobile UI
![image](https://github.com/code100x/daily-code/assets/53070244/13141b6e-7d30-4b9d-a0f0-74e20e01593b)

Resolves #[[371](https://github.com/code100x/daily-code/issues/371)] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
