### PR TITLE
replaced 'docker compose' to 'docker-compose' in setupDB.sh

### DIFF
--- a/packages/db/setupDB.sh
+++ b/packages/db/setupDB.sh
@@ -59,7 +59,7 @@ fi
 
 echo "DATABASE_URL=\"$DATABASE_URL\"" > .env
 if [ "$db_mode" == 'D' ]; then
-  docker compose up -d
+  docker-compose up -d
   if [ $? -eq 0 ]; then
       echo "=================Container is up================="
       sleep 15


### PR DESCRIPTION
### PR Fixes:
- 1 fixed : error occurred when running setupDB.sh. 
below is the error screenshot.  error is solved when replaced 'docker compose' to 'docker-compose' in setupDB.sh
![error_daily_code](https://github.com/code100x/daily-code/assets/80573084/55e24064-4df3-410d-9abc-24d2ec4c3bf2)

Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
