### PR TITLE
Fixed the "Copied!!" popup when copying the code

### DIFF
--- a/packages/ui/app/CodeBlock.module.css
+++ b/packages/ui/app/CodeBlock.module.css
@@ -36,5 +36,4 @@
     background: #fff;
     padding: 5px;
     color: #161b22;
-    display: none;
 }

--- a/packages/ui/src/CodeBlock.tsx
+++ b/packages/ui/src/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import hljs from "highlight.js";
 import javascript from "highlight.js/lib/languages/javascript";
 import styles from "../app/CodeBlock.module.css";
@@ -7,13 +7,12 @@ import "highlight.js/styles/github-dark.css";
 export default function CodeBlock({ block }: { block: any }) {
   const code: string = block.properties.title[0].toString();
   hljs.registerLanguage("javascript", javascript);
-  console.log(block);
-  const copied_display_id = `copied_display_${block.id}`;
+
   useEffect(() => {
     hljs.highlightAll();
   }, []);
 
-  const copiedDisplayElement = document.getElementById(copied_display_id);
+  const [showCopiedMessage, setShowCopiedMessage] = useState(false);
 
   return (
     <div className="max-w-full overflow-auto">
@@ -24,20 +23,18 @@ export default function CodeBlock({ block }: { block: any }) {
             className={styles.copy_button}
             onClick={() => {
               navigator.clipboard.writeText(code).then(() => {
-                if (copiedDisplayElement) {
-                  copiedDisplayElement.style.display = "block";
-                  setTimeout(() => {
-                    copiedDisplayElement.style.display = "none";
-                  }, 1000);
-                }
+                setShowCopiedMessage(true);
+                setTimeout(() => {
+                  setShowCopiedMessage(false);
+                }, 1000);
               });
             }}
           >
             Copy
           </button>
-          <div id={copied_display_id} className={styles.copied_text}>
-            Copied!!
-          </div>
+          {showCopiedMessage && (
+            <div className={styles.copied_text}>Copied!!</div>
+          )}
         </div>
       </pre>
     </div>


### PR DESCRIPTION
### PR Fixes:
- 1 The "copied" popup was not coming up consistently, made a state variable and did conditional rendering for the popup

Before 
![image](https://github.com/code100x/daily-code/assets/51535996/3398257d-dad8-4dbb-aaa8-c4113940fbae)

After
![image](https://github.com/code100x/daily-code/assets/51535996/623fc585-52bf-4544-86fc-d1bf4504a5f2)


### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
