### PR TITLE
updated inital DB setup setupDB.sh

### DIFF
--- a/packages/db/setupDB.sh
+++ b/packages/db/setupDB.sh
@@ -30,7 +30,7 @@ if [ "$db_type" == 'L' ]; then
     read is_username
 
     if [ "$is_username" == "Y" ];then
-      echo "Enter your db password: "
+      echo "Enter your db username: "
       read db_username
     else
       db_username="postgres"


### PR DESCRIPTION
### PR Fixes:
- 1 In the initial DB setup, when we ask for db's username, the script prompts `Enter your db password: ` which creates confusion and error while setting up. Updated that to `Enter your db username: `

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
