### PR TITLE
Fix : keypress handler for Cmd+K on macOS and Ctrl+K on Windows

### DIFF
--- a/packages/ui/src/SearchDialog.tsx
+++ b/packages/ui/src/SearchDialog.tsx
@@ -11,15 +11,15 @@ import Link from "next/link";
 
 export function SearchDialog({ tracks }: { tracks: (Track & { problems: Problem[] })[] }) {
   const [dialogOpen, setDialogOpen] = useState(false);
-  const scrollableContainerRef
-    = useRef<HTMLDivElement>(null);
+  const scrollableContainerRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState("");
   const [searchTracks, setSearchTracks] = useState(tracks);
   const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [shortcut, setShortcut] = useState("Ctrl K");
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
-      if ((event.code === "KeyK" && (event.ctrlKey || event.metaKey))) {
+      if (event.code === "KeyK" && event.ctrlKey) {
         event.preventDefault();
         setDialogOpen(true);
       } else if (event.code === "ArrowDown") {
@@ -51,6 +51,11 @@ export function SearchDialog({ tracks }: { tracks: (Track & { problems: Problem[
   }, [searchTracks, selectedIndex]);
 
   useEffect(() => {
+    const isMacOS = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+    setShortcut(isMacOS ? "Cmd K" : "Ctrl K");
+  }, []);
+
+  useEffect(() => {
     const foundTracks = tracks.filter((track) => {
       return (
         track.title.toLowerCase().includes(input.toLowerCase()) ||
@@ -72,7 +77,7 @@ export function SearchDialog({ tracks }: { tracks: (Track & { problems: Problem[
         <div className="items-center hidden gap-2 md:flex">
           <MagnifyingGlassIcon className="h-[1.2rem] w-[1.2rem]" />
           Search...
-          <kbd className="bg-white/15 p-1.5 rounded-sm text-xs leading-3">Ctrl K</kbd>
+          <kbd className="bg-white/15 p-1.5 rounded-sm text-xs leading-3">{shortcut}</kbd>
         </div>
         <div className="block md:hidden">
           <MagnifyingGlassIcon className="h-[1.2rem] w-[1.2rem]" />

--- a/packages/ui/src/SearchDialog.tsx
+++ b/packages/ui/src/SearchDialog.tsx
@@ -19,7 +19,7 @@ export function SearchDialog({ tracks }: { tracks: (Track & { problems: Problem[
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
-      if (event.code === "KeyK" && event.ctrlKey) {
+      if ((event.code === "KeyK" && (event.ctrlKey || event.metaKey))) {
         event.preventDefault();
         setDialogOpen(true);
       } else if (event.code === "ArrowDown") {


### PR DESCRIPTION
### PR Fixes:
- 1 Ensure the dialog opens with Cmd+K on macOS and Ctrl+K on Windows.
This change checks for both metaKey and ctrlKey to provide cross-platform
support. Additionally, the keypress handler has been optimized for better
readability and maintainability. Mac users press Cmd+K only to open a search.

Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
