### PR TITLE
feat: added track preview & fixed small bugs

### DIFF
--- a/apps/web/components/TrackCard.tsx
+++ b/apps/web/components/TrackCard.tsx
@@ -1,7 +1,10 @@
+"use client";
 import { Card, CardDescription, CardHeader, CardTitle, Button } from "@repo/ui";
-
 import { ArrowRightIcon, ChevronRightIcon } from "@radix-ui/react-icons";
 import { Track, Problem } from "@prisma/client";
+import { useState } from "react";
+import { TrackPreview } from "./TrackPreview";
+import Link from "next/link";
 
 interface TrackCardProps extends Track {
   problems: Problem[];
@@ -14,30 +17,51 @@ interface TrackCardProps extends Track {
 }
 
 export function TrackCard({ track }: { track: TrackCardProps }) {
+  const [showPreview, setShowPreview] = useState<boolean>(false);
+
   return (
-    <Card className="max-w-screen-md w-full cursor-pointer transition-all hover:border-primary/20 shadow-lg dark:shadow-black/60">
-      <CardHeader>
-        <div className="flex flex-col sm:flex-row">
-          <img src={track.image} className="min-h-[130px] sm:h-[130px] min-w-[130px] sm:w-[130px] rounded-xl"></img>
-          <div className="pt-4 sm:pt-0 sm:pl-4">
-            <CardTitle>{track.title}</CardTitle>
-            <div>{track.description}</div>
-            <CardDescription>
-              {track.categories.map((item) => {
-                return <div key={item.category.id}>{item.category.category}</div>;
-              })}
-            </CardDescription>
+    <>
+      <Card
+        className="max-w-screen-md w-full cursor-pointer transition-all hover:border-primary/20 shadow-lg dark:shadow-black/60"
+        onClick={() => setShowPreview(true)}
+      >
+        <CardHeader>
+          <div className="flex flex-col sm:flex-row">
+            <img src={track.image} className="min-h-[130px] sm:h-[130px] min-w-[130px] sm:w-[130px] rounded-xl"></img>
+            <div className="pt-4 sm:pt-0 sm:pl-4 flex flex-col justify-between">
+              <div>
+                <CardTitle>{track.title}</CardTitle>
+                <CardDescription>
+                  <div>{track.description.slice(0, 180) + (track.description.length > 180 ? "..." : "")}</div>
+                </CardDescription>
+              </div>
+              <div>
+                {track.categories.map((item, idx) => (
+                  <p key={item.category.id} className="inline-block">
+                    {item.category.category}{" "}
+                    <span className={`${track.categories[idx + 1] ? "inline-block" : "hidden"}`}> |&nbsp;</span>
+                  </p>
+                ))}
+              </div>
+            </div>
           </div>
-        </div>
-        <div className="flex justify-between">
-          <h3 className="flex flex-col justify-center">{track.problems.length} Lessons</h3>
-          <Button size={"lg"} className="flex items-center justify-center group">
-            Explore
-            <ChevronRightIcon className="pl-1 h-4 w-4 group-hover:translate-x-1 group-hover:hidden mt-[0.15rem] transition-all duration-150" />
-            <ArrowRightIcon className="pl-1 h-4 w-4 hidden group-hover:block mt-[0.15rem] transition-all duration-150" />
-          </Button>
-        </div>
-      </CardHeader>
-    </Card>
+          <div className="flex justify-between">
+            <h3 className="flex flex-col justify-center">{track.problems.length} Lessons</h3>
+            <Link href={track.problems.length ? `/tracks/${track.id}/${track.problems[0]?.id}` : ""}>
+              <Button
+                size={"lg"}
+                className="flex items-center justify-center group"
+                onClick={(e) => e.stopPropagation()}
+              >
+                Start
+                <ChevronRightIcon className="pl-1 h-4 w-4 group-hover:translate-x-1 group-hover:hidden mt-[0.15rem] transition-all duration-150" />
+                <ArrowRightIcon className="pl-1 h-4 w-4 hidden group-hover:block mt-[0.15rem] transition-all duration-150" />
+              </Button>
+            </Link>
+          </div>
+        </CardHeader>
+      </Card>
+      <TrackPreview showPreview={showPreview} setShowPreview={setShowPreview} track={track} />
+    </>
   );
 }

--- a/apps/web/components/TrackPreview.tsx
+++ b/apps/web/components/TrackPreview.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { Button } from "../../../packages/ui/src/shad/ui/button";
+import { Dialog, DialogContent } from "../../../packages/ui/src/shad/ui/dailog";
+
+type TrackPreviewProps = {
+    showPreview: boolean;
+    setShowPreview: (val: boolean) => void;
+    track: any;
+}
+
+export function TrackPreview({ showPreview, setShowPreview, track }: TrackPreviewProps) {
+  return (
+    <Dialog open={showPreview} onOpenChange={() => setShowPreview(false)}>
+      <DialogContent className="max-w-2xl max-h-[90vh]">
+        <div className="p-5">
+          <div className="mb-6 relative">
+            <img src={track.image} className="h-20 w-full object-cover rounded-lg" />
+            <div className="text-3xl backdrop-blur-md font-black absolute w-full text-center -translate-y-14 drop-shadow-[2px_2px_var(--tw-shadow-color)] dark:shadow-stone-900 shadow-stone-100">
+              {track.title}
+            </div>
+          </div>
+          {track.categories.map((item: any, idx: number) => (
+            <p key={item.category.id} className="inline-block text-sm font-extrabold mb-3 px-5">
+              {item.category.category}{" "}
+              <span className={`${track.categories[idx + 1] ? "inline-block" : "hidden"}`}> |&nbsp;</span>
+            </p>
+          ))}
+          <p className="pb-5 px-5">{track.description}</p>
+          <hr />
+          <p className="mt-5 font-bold px-5 text-xl">Contents</p>
+          <div className="max-h-[40vh] overflow-y-auto">
+            {track.problems.map((topic: any, idx: number) => (
+                <Link href={`/tracks/${track.id}/${track.problems[idx]?.id}`}>
+              <div className="hover:cursor-pointer my-2 rounded-md dark:hover:bg-slate-700 hover:bg-slate-200 px-5 py-1 transition-all duration-450 scroll-smooth">
+                {topic.title}
+              </div>
+              </Link>
+            ))}
+          </div>
+          <div className="w-full flex justify-center">
+            <Link href={track.problems.length ? `/tracks/${track.id}/${track.problems[0]?.id}` : ""}>
+              <Button
+                size={"lg"}
+                className="flex items-center justify-center group"
+                onClick={(e) => e.stopPropagation()}
+              >
+                Start
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -1,5 +1,5 @@
 "use client";
-import Link from "next/link";
+
 import { TrackCard } from "./TrackCard";
 import { category } from "@repo/store";
 import { Track, Problem } from "@prisma/client";
@@ -19,8 +19,9 @@ interface Tracks extends Track {
 
 export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
   const selectedCategory = useRecoilValue(category);
-  const [filteredTracks, setFilteredTracks] = useState(tracks);
-  const [sortBy, setSortBy] = useState("");
+  const [filteredTracks, setFilteredTracks] = useState<Tracks[]>(tracks);
+  const [sortBy, setSortBy] = useState<string>("");
+  
   const filterTracks = () => {
     let filteredTracks = tracks;
     if (selectedCategory.length > 0) {
@@ -69,13 +70,7 @@ export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
       <ul className="p-8 md:20 grid grid-cols-1 gap-x-6 gap-y-8 place-items-center lg:grid-cols-2 w-full">
         {filteredTracks.map((t) => (
           <li key={t.id} className="max-w-screen-md w-full">
-            {t.problems.length > 0 ? (
-              <Link className="w-full" href={`/tracks/${t.id}/${t.problems[0]?.id}`}>
                 <TrackCard track={t} />
-              </Link>
-            ) : (
-              <TrackCard track={t} />
-            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
### PR Feature:
- **Added tracks preview feature** 
   - View the complete description.
   - Check all the contents of that particular track on the home page instead of going to track's page.
   - Navigate directly to a particular track chapter or start from the beginning.
- **Fixed few minor bugs**
   - Fixed the description length in the track card to make the card size uniform.
   - In the case of multiple categories for a track, the categories would be on top of one another. Fixed it with cleaner by | separating it (e.g. Web Development | Projects).
   

https://github.com/code100x/daily-code/assets/86565216/7824f037-ea8d-4084-aadc-a50f52cfeff8




### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
