### PR TITLE
fixes appbar light theme issue

### DIFF
--- a/apps/web/components/BlogAppbar.tsx
+++ b/apps/web/components/BlogAppbar.tsx
@@ -119,7 +119,7 @@ export const BlogAppbar = ({
           >
             <Button
               variant="outline"
-              className="ml-2 bg-black text-white md:flex hidden"
+              className="ml-2 md:flex hidden"
               disabled={problemIndex !== 0 ? false : true}
             >
               <div className="pr-2">
@@ -129,7 +129,7 @@ export const BlogAppbar = ({
             </Button>
             <Button
               variant="outline"
-              className=" bg-black text-white md:hidden block"
+              className="md:hidden block"
               disabled={problemIndex !== 0 ? false : true}
             >
               <div>
@@ -149,7 +149,7 @@ export const BlogAppbar = ({
           >
             <Button
               variant="outline"
-              className="bg-black text-white md:flex hidden"
+              className="md:flex hidden"
               disabled={problemIndex + 1 !== track.problems.length ? false : true}
             >
               Next
@@ -159,7 +159,7 @@ export const BlogAppbar = ({
             </Button>
             <Button
               variant="outline"
-              className="bg-black text-white md:hidden block"
+              className="md:hidden block"
               disabled={problemIndex + 1 !== track.problems.length ? false : true}
             >
               <div>
@@ -169,13 +169,13 @@ export const BlogAppbar = ({
           </Link>
           <ModeToggle />
           <Link href={`/pdf/${track.id}/${track.problems[problemIndex]!.id}`} target="_blank">
-            <Button variant="outline" className="ml-2 bg-black text-white md:flex hidden">
+            <Button variant="outline" className="ml-2 md:flex hidden">
               Download
               <div className="pl-2">
                 <DownloadIcon />
               </div>
             </Button>
-            <Button variant="outline" className=" bg-black text-white md:hidden block">
+            <Button variant="outline" className="md:hidden block">
               <div>
                 <DownloadIcon />
               </div>


### PR DESCRIPTION
### PR Fixes:
- 1 Fixes light theme issue for app bar Prev/Next/Download Button
- 2 Fixes light theme issue for both smaller and bigger screen

Resolves #275  

There was closed PR raised for this, since no one was assigned to issue hence I took it.
@hkirat please merge this

Before:-
![image](https://github.com/code100x/daily-code/assets/100834122/9956f511-7fe5-4152-a92f-839c14081a18)
![image](https://github.com/code100x/daily-code/assets/100834122/d46d9505-a59d-46da-bc22-c6b1af71d442)

After fix:- 
![image](https://github.com/code100x/daily-code/assets/100834122/61464469-32ae-429d-80f4-9f37c0b32c81)
![image](https://github.com/code100x/daily-code/assets/100834122/5e874bdd-11c5-43d7-8c8b-12b1dd59031a)


### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
