### PR TITLE
[Feature] Add "Go to Top" Button on Every Learning Track Page

### DIFF
--- a/apps/web/app/tracks/[...trackIds]/page.tsx
+++ b/apps/web/app/tracks/[...trackIds]/page.tsx
@@ -4,6 +4,7 @@ import { redirect, notFound } from "next/navigation";
 import { getAllTracks, getProblem, getTrack } from "../../../components/utils";
 import { cache } from "react";
 import { LessonView } from "../../../components/LessonView";
+import ScrollToTopWrapper from "../../../components/ScrollToTopWrapper";
 
 const notion = new NotionAPI();
 export const dynamic = "auto";
@@ -49,14 +50,16 @@ export default async function TrackComponent({ params }: { params: { trackIds: s
   if (trackDetails && problemDetails) {
     return (
       <div>
-        <LessonView
-          showAppBar
-          track={trackDetails}
-          problem={{
-            ...problemDetails,
-            notionRecordMap,
-          }}
-        />
+        <ScrollToTopWrapper>
+          <LessonView
+            showAppBar
+            track={trackDetails}
+            problem={{
+              ...problemDetails,
+              notionRecordMap,
+            }}
+          />
+        </ScrollToTopWrapper>
       </div>
     );
   } else {

--- a/apps/web/components/ScrollToTopWrapper.tsx
+++ b/apps/web/components/ScrollToTopWrapper.tsx
@@ -1,0 +1,14 @@
+"use client"
+import React from "react";
+import ScrollToTop from "react-scroll-to-top";
+const ScrollToTopWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div>
+      <ScrollToTop smooth
+      className={"flex justify-center items-center"}/>
+      {children}
+    </div>
+  );
+};
+
+export default ScrollToTopWrapper;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.5.2",
-    "@repo/common": "*",
     "@icons-pack/react-simple-icons": "^9.4.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.0.2",
+    "@repo/common": "*",
     "@repo/db": "*",
     "@repo/ui": "*",
     "class-variance-authority": "^0.7.0",
@@ -25,6 +25,7 @@
     "notion-client": "^6.16.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-scroll-to-top": "^3.0.0",
     "recoil": "^0.7.7",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5893,6 +5893,11 @@ react-resizable-panels@^1.0.9:
   resolved "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-1.0.9.tgz"
   integrity sha512-QPfW3L7yetEC6z04G9AYYFz5kBklh8rTWcOsVFImYMNUVhr1Y1r9Qc/20Yks2tA+lXMBWCUz4fkGEvbS7tpBSg==
 
+react-scroll-to-top@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-scroll-to-top/-/react-scroll-to-top-3.0.0.tgz#002984419d4d10fdb5654c9e3dd3341f81209a60"
+  integrity sha512-I/k45Ujai097du59tHBbzGxN7Lyc6K8Uc3IChq6HMXaBfB8N/rrfm055T5Yv0DWfVpf6pOFaBmhD3LOfH5unGw==
+
 react-style-singleton@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz"


### PR DESCRIPTION
### PR Fixes:

1. Adds a "Go to Top" button on every learning track page.
2. Enhances user navigation experience by allowing users to quickly return to the top of the page.

Resolves  [#451]



### Description:

This PR introduces a "Go to Top" button on every learning track page within the DailyCode platform. This feature enhances the user experience by providing a convenient way for users to quickly return to the top of the page.

### Implementation Details:

Added a `ScrollToTopWrapper` component using the `react-scroll-to-top` library.
Wrapped the track pages with the ScrollToTopWrapper component to enable the "Go to Top" functionality.

### Before:

![Screenshot from 2024-05-29 23-09-43](https://github.com/code100x/daily-code/assets/68776478/4d191307-49bb-4b37-84c9-5d213b0e5b8e)


### After:

![Screenshot from 2024-05-29 23-10-23](https://github.com/code100x/daily-code/assets/68776478/580d987a-b61e-400b-b538-413d0a0bc0ff)


### Checklist before requesting a review
 

- [x] I have performed a self-review of my code.

 

- [x] I assure there is no similar/duplicate pull request regarding the same issue.