### PR TITLE
 BugFix: when clicked on one of the items of the sort dropdown, it is…

### DIFF
--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -21,7 +21,6 @@ export const Tracks = ({ tracks }: { tracks: TrackPros[] }) => {
   const selectedCategory = useRecoilValue(category);
   const [filteredTracks, setFilteredTracks] = useState<TrackPros[]>(tracks);
   const [sortBy, setSortBy] = useState<string>("");
-
   const [selectOpen, setSelectOpen] = useState<boolean>(false);
   const [cohort3, setCohort3] = useState<boolean>(false);
 

--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -21,6 +21,8 @@ export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
   const selectedCategory = useRecoilValue(category);
   const [filteredTracks, setFilteredTracks] = useState<Tracks[]>(tracks);
   const [sortBy, setSortBy] = useState<string>("");
+  const [selectOpen, setSelectOpen] = useState<boolean>(false);
+
   
   const filterTracks = () => {
     let filteredTracks = tracks;
@@ -51,6 +53,8 @@ export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
   return (
     <div>
       <Select
+        open = {selectOpen}
+        onOpenChange={() => { setTimeout(() => { setSelectOpen(!selectOpen); }, 20); }}
         onValueChange={(e) => {
           setSortBy(e);
         }}

--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -21,7 +21,7 @@ export const Tracks = ({ tracks }: { tracks: TrackPros[] }) => {
   const selectedCategory = useRecoilValue(category);
   const [filteredTracks, setFilteredTracks] = useState<TrackPros[]>(tracks);
   const [sortBy, setSortBy] = useState<string>("");
-  const [selectOpen, setSelectOpen] = useState<boolean>(false);
+  const [isSelectOpen, setIsSelectOpen] = useState<boolean>(false);
   const [cohort3, setCohort3] = useState<boolean>(false);
 
   const filterTracks = () => {

--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -58,7 +58,7 @@ export const Tracks = ({ tracks }: { tracks: TrackPros[] }) => {
       <div className="flex flex-col gap-4 md:flex-row items-center justify-evenly mt-6">
         <Select
           open = {isSelectOpen}
-          onOpenChange={() => { setTimeout(() => { setSelectOpen(!selectOpen); }, 20); }}
+          onOpenChange={() => { setTimeout(() => { setIsSelectOpen(!isSelectOpen); }, 20); }}
           onValueChange={(e) => {
             setSortBy(e);
           }}

--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -57,7 +57,7 @@ export const Tracks = ({ tracks }: { tracks: TrackPros[] }) => {
     <div>
       <div className="flex flex-col gap-4 md:flex-row items-center justify-evenly mt-6">
         <Select
-          open = {selectOpen}
+          open = {isSelectOpen}
           onOpenChange={() => { setTimeout(() => { setSelectOpen(!selectOpen); }, 20); }}
           onValueChange={(e) => {
             setSortBy(e);


### PR DESCRIPTION
When clicking on an item, the select value changes so quickly that the popper disappears and the touch event simultaneously clicks the element behind it

### PR Fixes:
- 1 Issue 459

Resolves #[[459](https://github.com/code100x/daily-code/issues/459)]

**To solve the issue with minimal code change, introduced a delay of 20(twenty) milliseconds. This doesn't seem to hamper UX also fixes the issue**

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

Solution is hacky but minimally.
Links to a [broader issue](https://github.com/radix-ui/primitives/issues/1658#issuecomment-1517705980)



