### PR TITLE
Fixed stopPropogation issue on mobile devices

### DIFF
--- a/apps/web/components/Blog.tsx
+++ b/apps/web/components/Blog.tsx
@@ -3,6 +3,7 @@ import { Problem, Track } from "@prisma/client";
 import { BlogAppbar } from "./BlogAppbar";
 import { NotionRenderer } from "./NotionRenderer";
 import useMountStatus from "../hooks/useMountStatus";
+import Pagination from "./Pagination";
 
 export const Blog = ({
   problem,
@@ -29,6 +30,9 @@ export const Blog = ({
     <div>
       {showAppBar && <BlogAppbar problem={problem} track={track} problemIndex={problemIndex}/>}
       <NotionRenderer recordMap={problem.notionRecordMap} />
+      <div className="justify-center pt-2">
+        <Pagination allProblems={track.problems} track={track} problemIndex={problemIndex} />
+      </div>
     </div>
   );
 };

--- a/apps/web/components/BlogAppbar.tsx
+++ b/apps/web/components/BlogAppbar.tsx
@@ -10,6 +10,7 @@ import { PageToggle } from "./PageToggle";
 import { useRouter } from "next/navigation";
 import UserAccountDropDown from "./UserAccountDropDown";
 import { Codebar } from "../components/code/Codebar";
+import Pagination from "./Pagination";
 
 export const BlogAppbar = ({
   problem,
@@ -109,64 +110,7 @@ export const BlogAppbar = ({
         </p>
         {problem.type === "Code" && problem.problemStatement && <Codebar problemStatement={problem.problemStatement} />}
         <div className="flex space-x-2 mb-2">
-          <div className="mb-2">
-            <PageToggle allProblems={track.problems} track={track} />
-          </div>
-          <Link
-            prefetch={true}
-            href={problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]!.id}` : ``}
-            style={{ cursor: problemIndex !== 0 ? "pointer" : "not-allowed" }}
-          >
-            <Button
-              variant="outline"
-              className="ml-2 bg-black text-white md:flex hidden"
-              disabled={problemIndex !== 0 ? false : true}
-            >
-              <div className="pr-2">
-                <ChevronLeftIcon />
-              </div>
-              Prev
-            </Button>
-            <Button
-              variant="outline"
-              className=" bg-black text-white md:hidden block"
-              disabled={problemIndex !== 0 ? false : true}
-            >
-              <div>
-                <ChevronLeftIcon />
-              </div>
-            </Button>
-          </Link>
-
-          <Link
-            prefetch={true}
-            href={
-              problemIndex + 1 === track.problems.length
-                ? ``
-                : `/tracks/${track.id}/${track.problems[problemIndex + 1]!.id}`
-            }
-            style={{ cursor: problemIndex + 1 !== track.problems.length ? "pointer" : "not-allowed" }}
-          >
-            <Button
-              variant="outline"
-              className="bg-black text-white md:flex hidden"
-              disabled={problemIndex + 1 !== track.problems.length ? false : true}
-            >
-              Next
-              <div className="pl-2">
-                <ChevronRightIcon />
-              </div>
-            </Button>
-            <Button
-              variant="outline"
-              className="bg-black text-white md:hidden block"
-              disabled={problemIndex + 1 !== track.problems.length ? false : true}
-            >
-              <div>
-                <ChevronRightIcon />
-              </div>
-            </Button>
-          </Link>
+          <Pagination allProblems={track.problems} track={track} problemIndex={problemIndex} />
           <ModeToggle />
           <Link href={`/pdf/${track.id}/${track.problems[problemIndex]!.id}`} target="_blank">
             <Button variant="outline" className="ml-2 bg-black text-white md:flex hidden">

--- a/apps/web/components/Pagination.tsx
+++ b/apps/web/components/Pagination.tsx
@@ -1,0 +1,76 @@
+import { Track, Problem } from "@prisma/client";
+import { PageToggle } from "./PageToggle";
+import Link from "next/link";
+import { Button } from "@repo/ui";
+import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+
+
+const Pagination = ({ allProblems, track ,problemIndex}: { allProblems: Problem[]; track: Track & { problems: Problem[] } ; problemIndex:number}) => {
+  return (
+    <div>
+              <div className="flex space-x-2 mb-2 justify-center ">
+          <div className="mb-2">
+            <PageToggle allProblems={track.problems} track={track} />
+          </div>
+          <Link
+            prefetch={true}
+            href={problemIndex !== 0 ? `/tracks/${track.id}/${track.problems[problemIndex - 1]!.id}` : ``}
+            style={{ cursor: problemIndex !== 0 ? "pointer" : "not-allowed" }}
+          >
+            <Button
+              variant="outline"
+              className="ml-2 bg-black text-white md:flex hidden"
+              disabled={problemIndex !== 0 ? false : true}
+            >
+              <div className="pr-2">
+                <ChevronLeftIcon />
+              </div>
+              Prev
+            </Button>
+            <Button
+              variant="outline"
+              className=" bg-black text-white md:hidden block"
+              disabled={problemIndex !== 0 ? false : true}
+            >
+              <div>
+                <ChevronLeftIcon />
+              </div>
+            </Button>
+          </Link>
+
+          <Link
+            prefetch={true}
+            href={
+              problemIndex + 1 === track.problems.length
+                ? ``
+                : `/tracks/${track.id}/${track.problems[problemIndex + 1]!.id}`
+            }
+            style={{ cursor: problemIndex + 1 !== track.problems.length ? "pointer" : "not-allowed" }}
+          >
+            <Button
+              variant="outline"
+              className="bg-black text-white md:flex hidden"
+              disabled={problemIndex + 1 !== track.problems.length ? false : true}
+            >
+              Next
+              <div className="pl-2">
+                <ChevronRightIcon />
+              </div>
+            </Button>
+            <Button
+              variant="outline"
+              className="bg-black text-white md:hidden block"
+              disabled={problemIndex + 1 !== track.problems.length ? false : true}
+            >
+              <div>
+                <ChevronRightIcon />
+              </div>
+            </Button>
+          </Link>
+     
+        </div>
+    </div>
+  )
+}
+
+export default Pagination

--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -58,7 +58,13 @@ export const Tracks = ({ tracks }: { tracks: Tracks[] }) => {
         <SelectTrigger className="w-[250px] mx-auto mt-6">
           <SelectValue placeholder="Sort by" />
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent
+        ref={(ref)=>{
+          if(!ref) return;
+          ref.ontouchstart = (e)=>{
+            e.preventDefault();
+          }
+        }}>
           <SelectGroup>
             <SelectItem value="ascending">Ascending (A to Z)</SelectItem>
             <SelectItem value="descending">Descending (Z to A)</SelectItem>


### PR DESCRIPTION
When clicking on an item, the select value changes so quickly that the popper disappears and the touch event simultaneously clicks the element behind it

### PR Fixes:
- 1 Bug 459
- 2

Resolves #[Issue Number if there] 
#459 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
