### PR TITLE
Advanced search functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ yarn-error.log*
 *.pem
 
 .idea/
+.history

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,10 +2,10 @@
 . "$(dirname "$0")/_/husky.sh"
 
 # Define the unwanted lock files
-unwanted_files=("package-lock.json" "pnpm-lock.yaml" "bun.lockb")
+unwanted_files="package-lock.json pnpm-lock.yaml bun.lockb"
 
 # Check for unwanted lock files in the staged changes
-for file in "${unwanted_files[@]}"; do
+for file in $unwanted_files; do
     if git diff --cached --name-only | grep -qE "^$file$"; then
         echo "Error: Commits containing '$file' are not allowed. Please use Yarn and remove this file from your commit."
         exit 1

--- a/apps/web/components/admin/LinkProblems.tsx
+++ b/apps/web/components/admin/LinkProblems.tsx
@@ -6,6 +6,7 @@ import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@repo/ui";
 import LinkCard from "./LinkCard";
+import Image from "next/image";
 
 interface LinkProblemsProps extends Track {
   problems: {
@@ -42,7 +43,8 @@ export const LinkProblems = ({ tracks }: { tracks: LinkProblemsProps[] }) => {
             {filteredTracks.map((track) => (
               <Card key={track.id}>
                 <div className="grid grid-cols-6">
-                  <img
+                  <Image
+                    alt="track-image"
                     src={track.image}
                     className="flex m-4 min-h-[130px] sm:h-[130px] min-w-[130px] sm:w-[130px] rounded-xl"
                   />


### PR DESCRIPTION
### PR Fixes:
- User can directly search for a topic and go to the required track(exact page numbers will also be shown along with the track) , instead of just searching for the track

This is useful because many times we remember the concept in a track , but forget in which track that concept is present in..so this PR might help the user.

Example: 
if i want to search for the topic "scaling ws server"
Earlier: 
![Screenshot from 2024-06-13 20-59-09](https://github.com/code100x/daily-code/assets/77537293/55020f70-09b6-42d4-8bc7-b3cf80255211)

I cant find the exact page/track where i can find my topic

But in this PR:
![Screenshot from 2024-06-13 20-59-57](https://github.com/code100x/daily-code/assets/77537293/af62e11c-31cf-4916-b8eb-e595d4f51d31)

Now I can get the track as well as the exact page where I can find my topic


### Checklist before requesting a review
- [ x] I have performed a self-review of my code
- [ x] I assure there is no similar/duplicate pull request regarding same issue
