### PR TITLE
Fixed: scroll bar issue in light mode & added close button

### DIFF
--- a/apps/web/components/TrackPreview.tsx
+++ b/apps/web/components/TrackPreview.tsx
@@ -1,17 +1,17 @@
 import Link from "next/link";
 import { Button } from "../../../packages/ui/src/shad/ui/button";
-import { Dialog, DialogContent } from "../../../packages/ui/src/shad/ui/dailog";
+import { Dialog, DialogClose, DialogContent } from "../../../packages/ui/src/shad/ui/dailog";
+import { ScrollArea } from "@repo/ui";
 
 type TrackPreviewProps = {
-    showPreview: boolean;
-    setShowPreview: (val: boolean) => void;
-    track: any;
-}
-
+  showPreview: boolean;
+  setShowPreview: (val: boolean) => void;
+  track: any;
+};
 export function TrackPreview({ showPreview, setShowPreview, track }: TrackPreviewProps) {
   return (
     <Dialog open={showPreview} onOpenChange={() => setShowPreview(false)}>
-      <DialogContent className="max-w-2xl max-h-[90vh]">
+      <DialogContent className="rounded-lg  ">
         <div className="p-5">
           <div className="mb-6 relative">
             <img src={track.image} className="h-20 w-full object-cover rounded-lg" />
@@ -19,25 +19,34 @@ export function TrackPreview({ showPreview, setShowPreview, track }: TrackPrevie
               {track.title}
             </div>
           </div>
-          {track.categories.map((item: any, idx: number) => (
-            <p key={item.category.id} className="inline-block text-sm font-extrabold mb-3 px-5">
-              {item.category.category}{" "}
-              <span className={`${track.categories[idx + 1] ? "inline-block" : "hidden"}`}> |&nbsp;</span>
-            </p>
-          ))}
+          <div className=" p-2 m-2 bg-gray-200 overflow-hidden rounded-lg text-xl h-fit w-fit text-zinc-600">
+            {track.categories.map((item: any, idx: number) => (
+              <p key={item.category.id} className="inline-block text-sm font-extrabold  ">
+                {item.category.category}{" "}
+                <span className={`${track.categories[idx + 1] ? "inline-block" : "hidden"}`}> |&nbsp;</span>
+              </p>
+            ))}
+          </div>
           <p className="pb-5 px-5">{track.description}</p>
           <hr />
           <p className="mt-5 font-bold px-5 text-xl">Contents</p>
-          <div className="max-h-[40vh] overflow-y-auto">
-            {track.problems.map((topic: any, idx: number) => (
+          <ScrollArea className="h-72 rounded-md border m-2">
+            <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
+              {track.problems.map((topic: any, idx: number) => (
                 <Link href={`/tracks/${track.id}/${track.problems[idx]?.id}`}>
-              <div className="hover:cursor-pointer my-2 rounded-md dark:hover:bg-slate-700 hover:bg-slate-200 px-5 py-1 transition-all duration-450 scroll-smooth">
-                {topic.title}
-              </div>
-              </Link>
-            ))}
-          </div>
-          <div className="w-full flex justify-center">
+                  <div className="hover:cursor-pointer my-2 rounded-md dark:hover:bg-slate-700 hover:bg-slate-200 px-5 py-1 transition-all duration-450 scroll-smooth">
+                    <li>{topic.title}</li>
+                  </div>
+                </Link>
+              ))}
+            </ul>
+          </ScrollArea>
+          <div className="w-full flex justify-center mt-4 gap-6">
+            <DialogClose asChild>
+              <Button type="button" variant="secondary" size={"lg"}>
+                Close
+              </Button>
+            </DialogClose>
             <Link href={track.problems.length ? `/tracks/${track.id}/${track.problems[0]?.id}` : ""}>
               <Button
                 size={"lg"}

--- a/apps/web/components/TrackPreview.tsx
+++ b/apps/web/components/TrackPreview.tsx
@@ -1,25 +1,52 @@
+"use client";
 import Link from "next/link";
-import { Button } from "../../../packages/ui/src/shad/ui/button";
-import { Dialog, DialogClose, DialogContent } from "../../../packages/ui/src/shad/ui/dailog";
+import { Button } from "@repo/ui";
+import { Dialog, DialogClose, DialogContent } from "@repo/ui";
 import { ScrollArea } from "@repo/ui";
+import { EnterIcon } from "@radix-ui/react-icons";
+import { useEffect, useState } from "react";
 
 type TrackPreviewProps = {
   showPreview: boolean;
   setShowPreview: (val: boolean) => void;
   track: any;
 };
+
+const truncateDescription = (text: string, wordLimit: number) => {
+  const words = text.split(" ");
+  if (words.length > wordLimit) {
+    return words.slice(0, wordLimit).join(" ") + " ...";
+  }
+  return text;
+};
 export function TrackPreview({ showPreview, setShowPreview, track }: TrackPreviewProps) {
+  const [isMediumOrLarger, setIsMediumOrLarger] = useState(false);
+
+  const updateScreenSize = () => {
+    setIsMediumOrLarger(window.innerWidth >= 768);
+  };
+
+  useEffect(() => {
+    updateScreenSize(); // Set the initial state
+    window.addEventListener("resize", updateScreenSize); // Add resize listener
+
+    return () => {
+      window.removeEventListener("resize", updateScreenSize); // Cleanup listener on unmount
+    };
+  }, []);
+
+  const truncatedDescription = isMediumOrLarger ? track.description : truncateDescription(track.description, 15);
   return (
     <Dialog open={showPreview} onOpenChange={() => setShowPreview(false)}>
-      <DialogContent className="rounded-lg  ">
-        <div className="p-5">
+      <DialogContent className="rounded-lg">
+        <div className="p-2">
           <div className="mb-6 relative">
             <img src={track.image} className="h-20 w-full object-cover rounded-lg" />
             <div className="text-3xl backdrop-blur-md font-black absolute w-full text-center -translate-y-14 drop-shadow-[2px_2px_var(--tw-shadow-color)] dark:shadow-stone-900 shadow-stone-100">
               {track.title}
             </div>
           </div>
-          <div className=" p-2 m-2 bg-gray-200 overflow-hidden rounded-lg text-xl h-fit w-fit text-zinc-600">
+          <div className="p-2 m-2 bg-gray-200 overflow-hidden rounded-lg text-xl h-fit w-fit text-zinc-600">
             {track.categories.map((item: any, idx: number) => (
               <p key={item.category.id} className="inline-block text-sm font-extrabold  ">
                 {item.category.category}{" "}
@@ -27,15 +54,18 @@ export function TrackPreview({ showPreview, setShowPreview, track }: TrackPrevie
               </p>
             ))}
           </div>
-          <p className="pb-5 px-5">{track.description}</p>
+          <p className="pb-5 px-3">{truncatedDescription}</p>
           <hr />
-          <p className="mt-5 font-bold px-5 text-xl">Contents</p>
+          <p className="mt-5 font-bold px-3 text-xl">Contents</p>
           <ScrollArea className="h-72 rounded-md border m-2">
             <ul className="my-6 ml-6 list-disc [&>li]:mt-2">
               {track.problems.map((topic: any, idx: number) => (
                 <Link href={`/tracks/${track.id}/${track.problems[idx]?.id}`}>
-                  <div className="hover:cursor-pointer my-2 rounded-md dark:hover:bg-slate-700 hover:bg-slate-200 px-5 py-1 transition-all duration-450 scroll-smooth">
+                  <div className="hover:cursor-pointer flex items-center justify-between my-2 rounded-md dark:hover:bg-slate-700 hover:bg-slate-200 md:px-5 py-1 transition-all duration-450 scroll-smooth">
                     <li>{topic.title}</li>
+                    <div className="pr-2">
+                      <EnterIcon />
+                    </div>
                   </div>
                 </Link>
               ))}


### PR DESCRIPTION
### PR Fixes:
- The scrollbar is now visible in light mode
- Added a new close button on the track-preview page
- Improved "Categories" layout on the track-preview page & some minor UI changes

**Before :**

https://github.com/code100x/daily-code/assets/142813623/68c25265-b8d0-4801-afba-3f450bbaa62d

**After :**

https://github.com/code100x/daily-code/assets/142813623/bcee785f-52b3-4bfc-a121-ea9cc1428371



Resolves #[Issue Number if there] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
