### PR TITLE
Fixed: copy button positioning

### DIFF
--- a/apps/web/components/CodeBlock.tsx
+++ b/apps/web/components/CodeBlock.tsx
@@ -20,7 +20,7 @@ export default function CodeBlock({ block }: { block: any }) {
         <code className="language-javascript">{code}</code>
         <div className={`${styles.copy_block} absolute top-0 right-0`}>
           <button
-            className=" text-gray-500"
+            className="text-gray-500  p-1"
             onClick={() => {
               navigator.clipboard.writeText(code).then(() => {
                 setShowCopiedMessage(true);


### PR DESCRIPTION
### PR Fixes:
- 1 Made the copy button's positioning better


Resolves #[[482](https://github.com/code100x/daily-code/issues/482#issue-2381541640)] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

### Before
![copy-button](https://github.com/code100x/daily-code/assets/78533868/ead13764-6832-4464-bf3d-ba8a11d2ccc1)

### After
![copy-button-fixed](https://github.com/code100x/daily-code/assets/78533868/1a669311-a38c-49ba-bf43-952baa923b44)

- the copy icon looks even bad in smaller code blocks
