### PR TITLE
Bug Fix: Add "Copied" Notification on Click of Copy Code Icon

### DIFF
--- a/apps/web/components/CodeBlock.tsx
+++ b/apps/web/components/CodeBlock.tsx
@@ -29,6 +29,7 @@ export default function CodeBlock({ block }: { block: any }) {
             }}
           >
             {showCopiedMessage ? <CopyTick /> : <CopyIcon />}
+            {showCopiedMessage && <p className="absolute border p-1 text-xs bg-gray-500 text-slate-100 rounded-sm right-7 top-1 z-10">Copied!</p>}
           </button>
       </div>
       <div className="max-w-full overflow-auto relative">


### PR DESCRIPTION
### PR Fixes:
- 1 Fixes the issue where clicking on the copy code icon does not notify the user with "copied."
- 2 Adds a notification that appears when the code is copied, providing clear feedback to the user.

Resolves #541  

![image](https://github.com/user-attachments/assets/b8097e9f-4e25-467a-90af-b99d3391dfc4)


### Checklist before requesting a review
I have performed a self-review of my code
I assure there is no similar/duplicate pull request regarding the same issue
