### PR TITLE
fixed overflow of categories

### DIFF
--- a/apps/web/components/Categories.tsx
+++ b/apps/web/components/Categories.tsx
@@ -27,14 +27,14 @@ export const Categories = ({ categories }: { categories: Category[] }) => {
 
   return (
     <div>
-      <div className="xl:hidden block">
+      <div className="2.5xl:hidden block">
         <SelectCategory
           categories={categories}
           selectedCategory={selectedCategory}
           handleCategoryChange={handleCategoryChange}
         />
       </div>
-      <div className="xl:block hidden">
+      <div className="2.5xl:block hidden">
         <ButtonCategory
           categories={categories}
           selectedCategory={selectedCategory}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -20,6 +20,9 @@ module.exports = {
       },
     },
     extend: {
+      screens: {
+        "2.5xl": "1730px",
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
### PR Fixes:
- 1) overflow of categories tab

Resolves overflow of categories:
The dropdown used to appear at 1280px i changed it to around 1730px where the overflow of text begins, we can adjust it according to our use, i have defined a custom screen width in talwind config file

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue

![image](https://github.com/user-attachments/assets/29b7b0f0-2f2b-4840-bb95-3ee536ab7b3b)
![image](https://github.com/user-attachments/assets/38514478-30e7-451e-bf44-ca20bb966c88)

