### PR TITLE
fix: Correct Tracks Sorting When Changing Categories or Sorting Options on Landing Page

### DIFF
--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -54,6 +54,8 @@ export const Tracks = ({ tracks, categories }: TracksWithCategoriesProps) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedCohort, setSelectedCohort] = useState<number | null>(null);
+  const [key, setKey] = useState<number>(new Date().getTime());
+  const [value, setValue] = useState<string | undefined>(undefined);
 
   const tracksPerPage = 10;
   const isCohort2Selected = selectedCohort === CohortGroup.Two;
@@ -70,6 +72,7 @@ export const Tracks = ({ tracks, categories }: TracksWithCategoriesProps) => {
         t.categories.some((c) => c.category.category === selectedCategory)
       );
     }
+    newFilteredTracks.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     setFilteredTracks(newFilteredTracks);
     setCurrentPage(1); // Reset to first page on filtering
     setLoading(false);
@@ -97,6 +100,9 @@ export const Tracks = ({ tracks, categories }: TracksWithCategoriesProps) => {
 
   useEffect(() => {
     filterTracks();
+    setValue(undefined);
+    setKey(new Date().getTime());
+    setSortBy("new");
   }, [selectedCategory, selectedCohort, tracks]);
 
   useEffect(() => {
@@ -170,7 +176,7 @@ export const Tracks = ({ tracks, categories }: TracksWithCategoriesProps) => {
           </div>
 
           {/* Sort */}
-          <Select onValueChange={(e) => setSortBy(e)}>
+          <Select key={key} value={value} onValueChange={(e) => setSortBy(e)}>
             <SelectTrigger className="w-[250px]">
               <SelectValue placeholder="Sort by" />
             </SelectTrigger>


### PR DESCRIPTION
### **Description:**
This PR addresses the issue where tracks were not maintaining the correct order when categories or sort options were changed on the Landing page.

### **Solution:**
- Introduced new states `key` and `value` for the sorting dropdown, ensuring that it resets to its default state whenever the category is changed. This allows the dropdown to be refreshed and display "Sort by" as the default.
- Ensured that after the tracks are filtered based on the selected category, they are always sorted by "newest first" by default. This provides a consistent experience when changing categories, as users expect to see the latest tracks first.
- Fixed the issue where the sorting dropdown would become unresponsive to re-selection of the same option. Now, users can re-select the same sorting option after a category change without needing to switch to another option first.

### **Solution Demo:** 
https://github.com/user-attachments/assets/571bf82b-c675-44fc-84b9-ce483c043068

### **Resolves:** 
Resolves: #676