### PR TITLE
fix tracks skeleton #684

### DIFF
--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -215,7 +215,7 @@ export const Tracks = ({ tracks, categories }: TracksWithCategoriesProps) => {
       </motion.ul>
 
       {/* Skeleton */}
-      {filteredTracks.length < tracksPerPage && (
+      {filteredTracks.length < tracksPerPage && loading && (
         <div className="flex items-center space-x-4 w-full h-24 bg-neutral-100 dark:bg-neutral-900 p-4 rounded-xl">
           <Skeleton className="h-12 w-12 rounded-2xl" />
           <div className="space-y-2">


### PR DESCRIPTION
### PR Fixes:
- `bug: Loading skeleton is shown while seeing tracks even if tracks are empty or after any filter/sort action. #684`

Resolves #684  
---
#### Before : 
![Screenshot from 2024-10-09 16-00-28](https://github.com/user-attachments/assets/1ae0ac46-0f91-4a63-a5cc-90ce0beebca3)
![Screenshot from 2024-10-09 16-09-38](https://github.com/user-attachments/assets/2a0eaf2d-30bb-49af-8e3e-51d01642a8f3)
---
#### After:
![Screenshot from 2024-10-09 16-08-43](https://github.com/user-attachments/assets/ce564d9a-1749-495f-936a-cc732b76724c)
![Screenshot from 2024-10-09 16-09-09](https://github.com/user-attachments/assets/6ee05168-ab67-4201-9709-38db1ab58fdf)

--- 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
