### PR TITLE
Sort by function fixed

### DIFF
--- a/apps/web/components/Tracks.tsx
+++ b/apps/web/components/Tracks.tsx
@@ -63,7 +63,7 @@ export const Tracks = ({ tracks, categories }: TracksWithCategoriesProps) => {
     setLoading(true);
     let newFilteredTracks = tracks;
     if (selectedCohort) {
-      newFilteredTracks = newFilteredTracks.filter((t) => t.cohort === selectedCohort);
+      newFilteredTracks = newFilteredTracks.filter((t) => t.cohort === selectedCohort || t.cohort === 0);
     }
     if (selectedCategory && selectedCategory !== "All") {
       newFilteredTracks = newFilteredTracks.filter((t) =>


### PR DESCRIPTION
### PR Fixes:
- 1 It was not filtering out because some article has the value cohort=0
- 2 Introduced an logical 'or' statement, where it will also filter cohort= {theSelectedCohortValue i.e 2 or 3} as well cohort=0

Resolves #716 

### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue
