### PR TITLE
fixed dockerfile bug :- Prisma failed to detect the libssl/openssl version to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY . .
 
 RUN  yarn install
 
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
+
 EXPOSE 3000
 
 CMD ["yarn", "run", "dev:docker"]


### PR DESCRIPTION
### PR Fixes:
- 1 resolved the error "Prisma failed to detect the libssl/openssl version to use",  while setting up application with docker
![daily-code-docker-bug](https://github.com/user-attachments/assets/d1421f28-2d36-4a1d-9b61-71ea679641c4)

Resolves #745 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
