### PR TITLE
fix: update husky pre-commit to use bash and remove deprecated lines

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,19 +1,14 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/bin/bash
 
-# Define the unwanted lock files
-unwanted_files=("package-lock.json" "pnpm-lock.yaml" "bun.lockb")
+# Check for unwanted lock files in staged changes
+if git diff --cached --name-only | grep -E '^(package-lock\.json|pnpm-lock\.yaml|bun\.lockb)$' > /dev/null; then
+  echo "Error: Commits containing 'package-lock.json', 'pnpm-lock.yaml', or 'bun.lockb' are not allowed."
+  echo "Please use Yarn and remove these files from your commit."
+  exit 1
+fi
 
-# Check for unwanted lock files in the staged changes
-for file in "${unwanted_files[@]}"; do
-    if git diff --cached --name-only | grep -qE "^$file$"; then
-        echo "Error: Commits containing '$file' are not allowed. Please use Yarn and remove this file from your commit."
-        exit 1
-    fi
-done
-
-# Allow only yarn.lock, not mandatory but should be the only lock file if present
-if git diff --cached --name-only | grep -qE "^(package-lock\.json|pnpm-lock\.yaml|bun\.lockb)$"; then
-    echo "Error: Only 'yarn.lock' is allowed as a lock file. Please remove any other lock files from your commit."
-    exit 1
+# Allow only yarn.lock (optional but exclusive)
+if git diff --cached --name-only | grep -E '^(package-lock\.json|pnpm-lock\.yaml|bun\.lockb)$' > /dev/null; then
+  echo "Error: Only 'yarn.lock' is allowed as a lock file. Please remove other lock files."
+  exit 1
 fi


### PR DESCRIPTION
# Fix Husky Pre-Commit Hook

## Overview
Fixes `.husky/pre-commit` syntax error, removes deprecated lines, and enforces lockfile validation for Husky v10.0.0.

## Issues
1. Bash array syntax error in POSIX shell.
2. Deprecated Husky lines breaking in v10.0.0.
3. Invalid lockfiles blocking commits.

## Fixes
1. Changed to `#!/bin/bash`.
2. Removed legacy Husky lines.
3. Added `grep -E` lockfile check:
   ```bash
   #!/bin/bash
   if git diff --cached --name-only | grep -E '^(package-lock\.json|pnpm-lock\.yaml|bun\.lockb)$'; then
     echo "Error: Only 'yarn.lock' allowed. Remove other lockfiles."
     exit 1
   fi
   ```

## Testing
- Valid commits pass.
- Invalid lockfiles blocked.
- `yarn.lock` commits work.
- Script runs without errors.

## Verification
1. Commit test file: `echo "test" > test.txt && git add test.txt && git commit`.
2. Try invalid lockfile: `echo "{}" > package-lock.json && git add package-lock.json && git commit`.
3. Test `yarn.lock`; verify success.
4. Run `.husky/pre-commit` manually.

## Screenshot
Blocked commit for `package-lock.json`:  
![Screenshot](https://github.com/user-attachments/assets/b578d7c8-b486-42e3-addf-6fcebd3808f3)

## Notes
- CLI/Prisma fix in separate PR.
- Ensure `.husky/` configured for `core.hooksPath`.

Thanks for reviewing!