### PR TITLE
fix: Selection enabled below BlogAppBar

### DIFF
--- a/apps/web/components/BlogAppbar.tsx
+++ b/apps/web/components/BlogAppbar.tsx
@@ -166,7 +166,7 @@ export const BlogAppbar = ({
     ) : (
       <>
         <motion.div
-          className={`z-[50] flex w-full flex-col justify-between gap-2 p-6 md:flex-row ${visible ? "translate-y-0" : "-translate-y-full"}`}
+          className={`z-[50] flex w-full flex-col justify-between gap-2 pt-6 px-6 pb-0 md:flex-row ${visible ? "translate-y-0" : "-translate-y-full"}`}
           initial={{ y: 0 }}
           animate={{ y: visible ? 0 : -100 }}
           transition={{ duration: 0.3 }}


### PR DESCRIPTION
**Summary**
This PR fixes the padding in the Blog Appbar, so that selection below the app bar is enabled.

**Image of the issue ( Before )**
![blogappbar-selection-before](https://github.com/user-attachments/assets/fc281376-9d3e-452d-b387-a7c86aadf9d2)


**Image of the Fix ( After )**
![blogappbar-selection](https://github.com/user-attachments/assets/0afdaa79-1102-423c-a969-2dd1feffb64b)


### PR Fixes:
- 1 Changed the CSS class of the blog app bar <motion.div> to adjust the padding.
- 2 Padding changed from `p-6` to `pt-6 px-6 pb-0` to change bottom padding to 0 and enable selection of below content.

Resolves #[743] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
