### PR TITLE
GitHub Actions workflow lint job actions/cache@v2 upgraded to actions/cache@v3

### DIFF
--- a/.github/workflows/lint_commit.yml
+++ b/.github/workflows/lint_commit.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Cache Yarn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/yarn
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
GitHub Actions workflow lint job actions/cache@v2 upgraded to actions/cache@v3

### PR Fixes:
- 1 Upgraded actions/cache@v2 to actions/cache@v3

Resolves GitHub Actions workflow lint_commit

### Checklist before requesting a review
- [ *] I have performed a self-review of my code
- [ *] I assure there is no similar/duplicate pull request regarding same issue
