### PR TITLE
added missing prism generate step to the Windows setup (updated read me)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ docker-compose up
 # Configure the database connection
 # Add your connection string to DATABASE_URL
 
+yarn prisma generate
 yarn prisma migrate dev
 yarn prisma db seed
 ```


### PR DESCRIPTION
### PR Fixes:
When setting up the project locally on Windows, running yarn prisma db seed fails with a PrismaClientInitializationError because the Prisma Client is not yet generated.

Adding an explicit yarn prisma generate step before running migrations resolves the issue.

Changes made:
Updated Windows setup instructions in README to include yarn prisma generate before yarn prisma migrate dev and yarn prisma db seed.

Why:
1. Prevents "stale Prisma Client" errors for new contributors.
2. Ensures a smoother onboarding experience when cloning the repo fresh.

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

### README diff
```diff
-yarn prisma migrate dev
-yarn prisma db seed
+yarn prisma generate
+yarn prisma migrate dev
+yarn prisma db seed
```