### PR TITLE
fix: dark mode toggle not working for copy button

### DIFF
--- a/apps/web/components/CodeBlock.tsx
+++ b/apps/web/components/CodeBlock.tsx
@@ -32,7 +32,7 @@ export default function CodeBlock({ block }: { block: any }) {
         <code className="language-javascript">{code}</code>
       </pre>
       <button className="text-gray-500 p-2 absolute top-2 right-2 hover:opacity-80" onClick={handleCopyClick}>
-        <Copy className="size-5 text-primary/50" />
+        <Copy className="size-5 " />
       </button>
     </div>
   );


### PR DESCRIPTION
### PR Fixes:
- Fixed dark mode toggle not updating correctly for slides copy icon when switching themes.

Resolves [#665] 

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding the same issue
- [x] My code follows the existing code style and conventions
- [x] I have tested the changes locally to verify they work

### Before
![Before Dark Mode Fix](https://github.com/user-attachments/assets/5940fe49-6ea6-45ea-a79d-2ccaf2eb3b70)
 
### After 
![After Dark Mode Fix](https://github.com/user-attachments/assets/4b8431be-9699-4ee8-9132-5e78234a4df9)
