### PR TITLE
fix(build): cap @qdrant/js-client-rest below 1.19.0 (Node 20 build fix)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "@auth/prisma-adapter": "^1.5.2",
     "@google/generative-ai": "^0.11.3",
     "@icons-pack/react-simple-icons": "^9.4.1",
-    "@qdrant/js-client-rest": "^1.9.0",
+    "@qdrant/js-client-rest": ">=1.9.0 <1.19.0",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@repo/db": "*",


### PR DESCRIPTION
CD builds have been failing (incl. the just-merged Notion fix) because with an empty yarn.lock the build resolves @qdrant/js-client-rest to 1.19.0, which requires Node >=22, but Dockerfile.prod uses node:20-alpine — yarn install fails.

Caps the range below 1.19.0 so it resolves to a Node 18+ compatible version. Unblocks CD so deploys can proceed.

Generated with [Devin](https://devin.ai)