### PR TITLE
fix(search): resolve Notion block type error breaking build

### DIFF
--- a/apps/web/lib/search.ts
+++ b/apps/web/lib/search.ts
@@ -22,7 +22,7 @@ export async function scrapeData({ trackId }: { trackId: string }) {
     track?.problems.map(async (problem: any) => {
       const notionDocId = problem.notionDocId;
       const notionPage = await fetchNotionPage(notion, notionDocId);
-      const titles = Object.values(notionPage?.block ?? {})
+      const titles = Object.values<any>(notionPage?.block ?? {})
         .map((block) => {
           const title = block?.value?.properties?.title;
           if (title && title[0] && title[0][0]) {


### PR DESCRIPTION
Follow-up to #768. Object.values(notionPage?.block ?? {}) lost its element type under next build (Property 'value' does not exist on type '{}'). Annotate as Object.values<any>. Unblocks CD.

Generated with [Devin](https://devin.ai)