### PR TITLE
fix(build): restrict tsconfig types to fix @types/minimatch build failure

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,6 +7,7 @@
       },
     ],
     "strictNullChecks": true,
+    "types": ["node", "react", "react-dom"],
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
Follow-up unblocking CD. A deprecated stub @types/minimatch (empty, no .d.ts) is pulled transitively and auto-included by TS, failing next build with 'Cannot find type definition file for minimatch'. Restrict compilerOptions.types to node/react/react-dom.

Generated with [Devin](https://devin.ai)