### PR TITLE
Fix PostgreSQL 18 Docker volume compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     healthcheck:
       test: [ 'CMD-SHELL', 'pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}' ]
       interval: 10s


### PR DESCRIPTION
### Bug Fixes:

### Checklist before requesting a review
- [ yes] I have performed a self-review of my code
- [ yes] I assure there is no similar/duplicate pull request regarding same issue


## Problem

The project currently uses `postgres:alpine` with the PostgreSQL data
volume mounted at `/var/lib/postgresql/data`.

The `postgres:alpine` image now resolves to PostgreSQL 18, which uses
a different data directory layout. As a result, the database container
fails to start with:

`there appears to be PostgreSQL data in /var/lib/postgresql/data`

## Fix

Update the PostgreSQL volume mount from:

`/var/lib/postgresql/data`

to:

`/var/lib/postgresql`

This follows the volume layout expected by the PostgreSQL 18 Docker image.


Question:
How this bug happened?
- we are using image: postgres:alpine 
- postgres:alpine is now resolving to a PostgreSQL 18+ image.
- and PostgreSQL 18's Docker image changed the recommended data directory layout. The new image expects the volume mounted at:
- form /var/lib/postgresql/data to /var/lib/postgresql
- The PostgreSQL image is explicitly detecting our old mount and refusing to start. 
- this new fix will work for postgresql 18 and + 

##Before fix 
<img width="1365" height="659" alt="Screenshot 2026-08-11 144253" src="https://github.com/user-attachments/assets/ce65a3e0-9978-4fea-bef4-6f8ca0376e32" />

##After fix 

<img width="1489" height="848" alt="Screenshot 2026-08-11 145144" src="https://github.com/user-attachments/assets/3e848c9a-003e-4615-8e21-a97960206504" />

